### PR TITLE
Fix deprecated selectors

### DIFF
--- a/styles/atomjison-grammar-syntax.less
+++ b/styles/atomjison-grammar-syntax.less
@@ -1,7 +1,7 @@
-atom-text-editor::shadow {
-    .source.jison,
-    .source.jisonlex {
-        .grammar-rule.token-def.jison {
+atom-text-editor.editor {
+    .syntax--source.syntax--jison,
+    .syntax--source.syntax--jisonlex {
+        .syntax--grammar-rule.syntax--token-def.syntax--jison {
             font-weight: bold;
             color: orange;
         }


### PR DESCRIPTION
Atom is dropping their usage of shadow DOM and instead switching to a `syntax--` prefix for syntax highlighting selectors:

> Starting from Atom v1.13.0, the contents of atom-text-editor elements are no longer encapsulated within a shadow DOM boundary. This means you should stop using :host and ::shadow pseudo-selectors, and prepend all your syntax selectors with syntax--. 

This change switches to use what Atom is currently automatically transforming the selectors to under the covers.