### PR TITLE
Update grammars

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,7 @@
+Copyright © 2014–2017 Chris Dibbern
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -5,10 +5,6 @@ Thanks to, and based in part on the following projects:
 1. [Bison improved plugin](https://github.com/EliaGeretto/language-bison-improved)  
 2. [Bison plugin](https://github.com/toroidal-code/language-bison)  
 3. [Lex/Flex plugin](https://github.com/maemre/language-lex-flex)  
- 
-To Do:  
-1. Jison technically allows inline %lex ... /lex sections. Support these.  
-2. Rules can be defined across multiple lines in Jison. Support this (currently breaks on, e.g., "TOKEN \\n\\t : RULE DEF;")  
 
 Contributions are greatly appreciated.  
 Please fork this repository and open a pull request to add snippets, make grammar tweaks, work on to-dos (above), etc. Thx!  

--- a/coffeelint.json
+++ b/coffeelint.json
@@ -1,0 +1,5 @@
+{
+  "max_line_length": {
+    "level": "ignore"
+  }
+}

--- a/grammars/jison.cson
+++ b/grammars/jison.cson
@@ -1,22 +1,29 @@
 "name": "Jison"
 scopeName: "source.jison"
-fileTypes: [
-  "jison"
-]
+fileTypes: ["jison"]
+
 patterns: [
   {
-    begin: "^(%%)$"                             # Has to be the first pattern
-    comment: "Match from first %% symbol to EOF"
-    captures:
-      0:
-        name: "meta.separator.section.jison"    # Match first %% symbol
+    # Like Bison
+    # (https://www.gnu.org/software/bison/manual/html_node/Grammar-Outline.html),
+    # Jison files are divided into four sections:
+    #   %{
+    #     Prologue
+    #   %}
+    #   Declarations
+    #   %%
+    #   Grammar rules
+    #   %%
+    #   Epilogue
+    # Because there can be more than one prologue, another way to look at Jison
+    # files is that they’re divided into three sections separated by %%, just
+    # like Jison Lex files.
+    begin: "%%"
+    beginCaptures: 0: name: "meta.separator.section.jison"
     patterns: [
       {
-        begin: "^(%%)$"                         # Has to be the first pattern
-        comment: "Match from second %% symbol to EOF"
-        captures:
-          0:
-            name: "meta.separator.section.jison"# Match second %% symbol
+        begin: "%%"
+        beginCaptures: 0: name: "meta.separator.section.jison"
         patterns: [
           {
             name:  "meta.section.epilogue.jison"
@@ -24,22 +31,21 @@ patterns: [
             patterns: [include: "#epilogue_section"]
           }
         ]
-      }
-      {
+      },{
         name:  "meta.section.rules.jison"
         begin: "(?!%%)"
         end:   "(?=%%)"
         patterns: [include: "#rules_section"]
       }
     ]
-  }
-  {
+  },{
     name:  "meta.section.declarations.jison"
     begin: "(?!%%)"
     end:   "(?=%%)"
     patterns: [include: "#declarations_section"]
   }
 ]
+
 
 repository:
   declarations_section:

--- a/grammars/jison.cson
+++ b/grammars/jison.cson
@@ -52,6 +52,59 @@ repository:
     patterns: [
       {include: "#comments"}
 
+      # Jison declarations sections can have lexers embedded between %lex and
+      # /lex.
+      {
+        begin: "^\\s*(%lex)\\s*$"
+        end:   "^\\s*(/lex)\\b"
+        # There may be a better choice of scope than “entity.name.tag”, but
+        # using a tag scope makes the start and end matches stand out. Also, the
+        # end match “/lex” is somewhat like an end tag.
+        beginCaptures: 1: name: "entity.name.tag.lexer.begin.jison"
+        endCaptures:   1: name: "entity.name.tag.lexer.end.jison"
+        # Simply setting the patterns object to {include: "source.jisonlex"}
+        # here doesn’t work for several reasons:
+        # - The Jison Lex grammar’s rules section treats /lex as a valid regex
+        #   pattern; /lex is the same as (?=lex).
+        # - The user-code section treats /lex as a division operator followed by
+        #   the identifier “lex”.
+        # - The user-code section also does not end.
+        # This is the Jison Lex grammar with end patterns that circumvent these
+        # issues.
+        patterns: [
+          {
+            begin: "%%"
+            end:   "(?=/lex)"
+            beginCaptures: 0: name: "meta.separator.section.jisonlex"
+            patterns: [
+              {
+                begin: "^%%"
+                end:   "(?=/lex)"
+                beginCaptures: 0: name: "meta.separator.section.jisonlex"
+                patterns: [
+                  {
+                    name:  "meta.section.user-code.jisonlex"
+                    begin: "(?!%%)"
+                    end:   "(?=/lex)"
+                    patterns: [include: "source.jisonlex#user_code_section"]
+                  }
+                ]
+              },{
+                name:  "meta.section.rules.jisonlex"
+                begin: "(?!%%)"
+                end:   "(?=^(?:%%|/lex))"
+                patterns: [include: "source.jisonlex#rules_section"]
+              }
+            ]
+          },{
+            name:  "meta.section.definitions.jisonlex"
+            begin: "(?!%%)"
+            end:   "(?=%%|/lex)"
+            patterns: [include: "source.jisonlex#definitions_section"]
+          }
+        ]
+      }
+
       {
         name:  "meta.section.prologue.jison"
         begin: "(?=%\\{)"

--- a/grammars/jison.cson
+++ b/grammars/jison.cson
@@ -1,8 +1,8 @@
+"name": "Jison"
 scopeName: "source.jison"
 fileTypes: [
   "jison"
 ]
-name: "Jison"
 patterns: [
   {
     begin: "^(%%)$"                             # Has to be the first pattern

--- a/grammars/jison.cson
+++ b/grammars/jison.cson
@@ -199,11 +199,11 @@ repository:
       {include: "#actions"}
       {include: "#include_declarations"}
       {
-        name:  "meta.grammar-rule.jison"
+        name:  "meta.rule.jison"
         begin: "\\b[\\p{Alpha}_](?:[\\w-]*\\w)?\\b"
         end:   ";"
-        beginCaptures: 0: name: "variable.grammar-rule.token-def.jison"
-        endCaptures:   0: name: "punctuation.terminator.grammar-rule.jison"
+        beginCaptures: 0: name: "entity.name.constant.rule-result.jison"
+        endCaptures:   0: name: "punctuation.terminator.rule.jison"
         patterns: [
           {include: "#comments"}
           {

--- a/grammars/jison.cson
+++ b/grammars/jison.cson
@@ -53,6 +53,8 @@ repository:
         patterns: [include: "#user_code_blocks"]
       }
 
+      {include: "#options_declarations"}
+
       {
         include: "#declarations"
       }
@@ -277,6 +279,51 @@ repository:
         name: "constant.numeric.c"
       }
     ]
+
+  options_declarations:
+    patterns: [
+      {
+        name:  "meta.options.jison"
+        begin: "%options\\b"
+        end:   "$"
+        beginCaptures: 0: name: "keyword.other.options.jison"
+        patterns: [
+          {
+            name:  "entity.name.constant.jison"
+            match: "\\b[\\p{Alpha}_](?:[\\w-]*\\w)?\\b"
+          },{
+            begin: "(=)\\s*"
+            end:   "(?<=['\"])|(?=\\s)"
+            beginCaptures: 1: name: "keyword.operator.option.assignment.jison"
+            patterns: [
+              {include: "quoted_strings"}
+              {
+                name:  "string.unquoted.jison"
+                match: "\\S+"
+              }
+            ]
+          }
+          {include: "quoted_strings"}
+        ]
+      }
+    ]
+
+  quoted_strings:
+    patterns: [
+      {
+        name:  "string.quoted.double.jison"
+        begin: '"'
+        end:   '"'
+        # https://github.com/atom/language-javascript/blob/master/grammars/javascript.cson
+        patterns: [include: "source.js#string_escapes"]
+      },{
+        name:  "string.quoted.single.jison"
+        begin: "'"
+        end:   "'"
+        patterns: [include: "source.js#string_escapes"]
+      }
+    ]
+
   block:
     patterns: [
       {

--- a/grammars/jison.cson
+++ b/grammars/jison.cson
@@ -42,7 +42,7 @@ repository:
         begin: "(?!^%%$)"
         end: "(?=^%%$)"
         comment: "Match the content of the first section"
-        name: "meta.section.first.jison"
+        name: "meta.section.declarations.jison"
         patterns: [
           {
             include: "#prologue"
@@ -63,7 +63,7 @@ repository:
         begin: "(?!^%%$)"
         end: "(?=^%%$)"
         comment: "Match the content of the second section"
-        name: "meta.section.second.jison"
+        name: "meta.section.rules.jison"
         patterns: [
           {
             include: "#comments"
@@ -82,7 +82,7 @@ repository:
         begin: "(?!^%%$)"
         end: "(?=^%%$)"
         comment: "Match the content of the third section"
-        name: "meta.section.third.jison"
+        name: "meta.section.epilogue.jison"
         patterns: [
           {
             include: "source.js"

--- a/grammars/jison.cson
+++ b/grammars/jison.cson
@@ -112,17 +112,81 @@ repository:
         patterns: [include: "#user_code_blocks"]
       }
 
+      # These declarations are supported by the original Jison.
       {include: "#options_declarations"}
+      {
+        name:  "keyword.other.declaration.$1.jison"
+        match: "%(ebnf|left|nonassoc|parse-param|right|start)\\b"
+      }
+
+      # These declarations are supported by the GerHobbelt fork.
+      {include: "#include_declarations"}
+      {
+        name:  "meta.code.jison"
+        begin: "%(code)\\b"
+        end:   "$"
+        beginCaptures: 0: name: "keyword.other.declaration.$1.jison"
+        patterns: [
+          # Note that GerHobbelt Jison supports
+          #   %code qualifier {code}
+          # but not Bison’s
+          #   %code {code}
+          # (https://www.gnu.org/software/bison/manual/html_node/_0025code-Summary.html).
+          {include: "#comments"}
+          {include: "#rule_actions"}
+          {
+            # GerHobbelt Jison supports “required”, Bison supports “requires”
+            # (https://www.gnu.org/software/bison/manual/html_node/_0025code-Summary.html).
+            name:  "keyword.other.code-qualifier.$1.jison"
+            match: "(init|required)"
+          }
+          {include: "#quoted_strings"}
+          {
+            name:  "string.unquoted.jison"
+            match: "\\b[\\p{Alpha}_](?:[\\w-]*\\w)?\\b"
+          }
+        ]
+      },{
+        # https://www.gnu.org/software/bison/manual/html_node/Token-Decl.html
+        name:  "meta.token.jison"
+        begin: "%(token)\\b"
+        end:   "$|(%%|;)"
+        beginCaptures: 0: name: "keyword.other.declaration.$1.jison"
+        endCaptures:   1: name: "punctuation.terminator.declaration.token.jison"
+        patterns: [
+          {include: "#comments"}
+          {include: "#numbers"}
+          {include: "#quoted_strings"}
+          {
+            name:  "invalid.unimplemented.jison"
+            match: "<[\\p{Alpha}_](?:[\\w-]*\\w)?>"
+          },{
+            name:  "entity.other.token.jison"
+            match: "\\S+"
+          }
+        ]
+      },{
+        name:  "keyword.other.declaration.$1.jison"
+        match: "%(debug|import|parser-type)\\b"
+      }
 
       {
-        include: "#declarations"
+        name:  "invalid.illegal.jison"
+        match: "%prec\\b"
+      },{
+        name:  "invalid.unimplemented.jison"
+        match: "%[\\p{Alpha}_](?:[\\w-]*\\w)?\\b"
       }
+
+      {include: "#numbers"}
+      {include: "#quoted_strings"}
     ]
 
   rules_section:
     patterns: [
       {include: "#comments"}
       {include: "#actions"}
+      {include: "#include_declarations"}
       {
         include: "#rules"
       }
@@ -130,39 +194,11 @@ repository:
 
   epilogue_section:
     patterns: [
-      {
-        include: "source.js"
-        comment: "Epilogue contains Javascript code only"
-      }
+      {include: "#user_code_include_declarations"}
+      {include: "source.js"}
     ]
 
 
-  declarations:
-    patterns: [
-      {
-        include: "#directives"
-      }
-      {
-        include: "#types"
-      }
-      {
-        include: "#symbols"
-      }
-      {
-        include: "#numbers"
-      }
-      {
-        include: "#block"
-      }
-      {
-        include: "#strings"
-      }
-      {
-        match: "\\;"
-        comment: "Semicolon can be only at the end of a union"
-        name: "punctuation.union-declaration.end.jison"
-      }
-    ]
   rules:
     patterns: [
       {
@@ -295,6 +331,7 @@ repository:
         endCaptures:   0: name: "punctuation.definition.action.end.jison"
         patterns: [include: "source.js"]
       }
+      {include: "#include_declarations"}
       {
         name:  "meta.action.jison"
         begin: "->"
@@ -328,6 +365,41 @@ repository:
         end:   "\\*/"
         beginCaptures: 0: name: "punctuation.definition.comment.begin.jison"
         endCaptures:   0: name: "punctuation.definition.comment.end.jison"
+      }
+    ]
+
+  include_declarations:
+    patterns: [
+      {
+        name:  "meta.include.jison"
+        begin: "(%(include))\\s*"
+        end:   "(?<=['\"])|(?=\\s)"
+        beginCaptures: 1: name: "keyword.other.declaration.$2.jison"
+        patterns: [include: "#include_paths"]
+      }
+    ]
+  user_code_include_declarations:
+    patterns: [
+      {
+        # This is almost identical to the patterns in the include_declarations
+        # object, but an %include must be at the beginning of a line in a user-
+        # code section.
+        name:  "meta.include.jison"
+        begin: "^(%include)\\s*"
+        end:   "(?<=['\"])|(?=\\s)"
+        beginCaptures: 1: name: "keyword.other.include.jison"
+        patterns: [include: "#include_paths"]
+      }
+    ]
+
+  include_paths:
+    patterns: [
+      {include: "#quoted_strings"}
+      {
+        name:  "string.unquoted.jison"
+        begin: "(?=\\S)"
+        end:   "(?=\\s)"
+        patterns: [include: "source.js#string_escapes"]
       }
     ]
 

--- a/grammars/jison.cson
+++ b/grammars/jison.cson
@@ -203,7 +203,7 @@ repository:
             include: "#symbols"
           }
           {
-            include: "#actions"
+            include: "#rule_actions"
           }
         ]
       }
@@ -244,32 +244,37 @@ repository:
         ]
       }
     ]
-  actions:
+
+  rule_actions:
     patterns: [
       {
-        begin: "\\{"
-        beginCaptures:
-          0:
-            name: "punctuation.action.begin.jison"
-        end: "\\}"
-        endCaptures:
-          0:
-            name: "punctuation.action.end.jison"
         name: "meta.action.jison"
-        comment: "Match action blocks associated with grammar rules"
-        patterns: [
-          # TODO: Patterns for $-variable go here, or inside block_innards
-          {
-            include: "source.js"
-          }
-          {
-            match: "\\$[$a-zA-Z\_][$a-zA-Z0-9\_]*",
-            name: "variable.interpolation.grammar-rule.jison",
-            comment: "A grammar rule variable reference."
-          }
-        ]
+        begin: "\\{"
+        end:   "\\}"
+        beginCaptures: 0: name: "punctuation.definition.action.begin.jison"
+        endCaptures:   0: name: "punctuation.definition.action.end.jison"
+        patterns: [include: "source.js"]
+      }
+      {
+        name:  "meta.action.jison"
+        begin: "->"
+        end:   "((//).*)?(?=$)"
+        beginCaptures:
+          0: name: "punctuation.definition.action.arrow.jison"
+        endCaptures:
+          1: name: "comment.line.double-slash.js"
+          2: name: "punctuation.definition.comment.js"
+        # TODO: The end pattern is based on the comment.line.double-slash.js
+        # pattern in
+        # https://github.com/atom/language-javascript/blob/master/grammars/javascript.cson.
+        # The end pattern of comment.line.double-slash.js is itself $, so $
+        # can’t be the end pattern here because it will never be matched. Is
+        # there an end pattern that can be used here that doesn’t duplicate a
+        # JavaScript grammar pattern?
+        patterns: [include: "source.js"]
       }
     ]
+
   comments:
     patterns: [
       {
@@ -309,5 +314,43 @@ repository:
             include: "source.js"
           }
         ]
+      }
+    ]
+
+
+# These are from https://github.com/GerHobbelt/jison/blob/master/lib/jison.js.
+injections:
+  "L:meta.action.jison -(comment | string), source.js.embedded.source":
+    patterns: [
+      {
+        name:  "variable.language.semantic-value.jison"
+        match: "\\${2}"
+      },{
+        name:  "variable.language.result-location.jison"
+        match: "@\\$"
+      },{
+        name:  "variable.language.stack-index-0.jison"
+        match: "##\\$|\\byysp\\b"
+      },{
+        name:  "support.variable.token-reference.jison"
+        match: "#\\S+#"
+      },{
+        name:  "variable.language.result-id.jison"
+        match: "#\\$"
+      },{
+        name:  "support.variable.token-value.jison"
+        match: "\\$(?:-?\\d+|[\\p{Alpha}_](?:[\\w-]*\\w)?)"
+      },{
+        name:  "support.variable.token-location.jison"
+        match: "@(?:-?\\d+|[\\p{Alpha}_](?:[\\w-]*\\w)?)"
+      },{
+        name:  "support.variable.stack-index.jison"
+        match: "##(?:-?\\d+|[\\p{Alpha}_](?:[\\w-]*\\w)?)"
+      },{
+        name:  "support.variable.token-id.jison"
+        match: "#(?:-?\\d+|[\\p{Alpha}_](?:[\\w-]*\\w)?)"
+      },{
+        name:  "keyword.other.jison"
+        match: "\\byy(?:clearin|erro[kr])\\b"
       }
     ]

--- a/grammars/jison.cson
+++ b/grammars/jison.cson
@@ -45,8 +45,12 @@ repository:
   declarations_section:
     patterns: [
       {
-        include: "#prologue"
+        name:  "meta.section.prologue.jison"
+        begin: "(?=%\\{)"
+        end:   "(?<=%\\})"
+        patterns: [include: "#user_code_blocks"]
       }
+
       {
         include: "#declarations"
       }
@@ -77,22 +81,6 @@ repository:
     ]
 
 
-  prologue:
-    patterns: [
-      begin: "%{"
-      end: "%}"
-      comment: "Match the prologues, first section only"
-      name: "meta.section.prologue.jison"
-      captures:
-        0:
-          name: "meta.separator.prologue.jison" # Match %{ and %} symbols
-      patterns: [
-        {
-          include: "source.js"
-          comment: "Prologues contain Javascript code only"
-        }
-      ]
-    ]
   declarations:
     patterns: [
       {

--- a/grammars/jison.cson
+++ b/grammars/jison.cson
@@ -69,6 +69,7 @@ repository:
             include: "#comments"
             comment: "jison supports C/C++ comments"
           }
+          {include: "#actions"}
           {
             include: "#rules"
           }
@@ -245,8 +246,25 @@ repository:
       }
     ]
 
+  actions:
+    patterns: [
+      {
+        name:  "meta.action.jison"
+        begin: "\\{\\{"
+        end:   "\\}\\}"
+        beginCaptures: 0: name: "punctuation.definition.action.begin.jison"
+        endCaptures:   0: name: "punctuation.definition.action.end.jison"
+        patterns: [include: "source.js"]
+      },{
+        name:  "meta.action.jison"
+        begin: "(?=%\\{)"
+        end:   "(?<=%\\})"
+        patterns: [include: "#user_code_blocks"]
+      }
+    ]
   rule_actions:
     patterns: [
+      {include: "#actions"}
       {
         name: "meta.action.jison"
         begin: "\\{"
@@ -314,6 +332,18 @@ repository:
             include: "source.js"
           }
         ]
+      }
+    ]
+
+  user_code_blocks:
+    patterns: [
+      {
+        name:  "meta.user-code-block.jison"
+        begin: "%\\{"
+        end:   "%\\}"
+        beginCaptures: 0: name: "punctuation.definition.user-code-block.begin.jison"
+        endCaptures:   0: name: "punctuation.definition.user-code-block.end.jison"
+        patterns: [include: "source.js"]
       }
     ]
 

--- a/grammars/jison.cson
+++ b/grammars/jison.cson
@@ -1,312 +1,312 @@
-'scopeName': 'source.jison'
-'fileTypes': [
+scopeName: 'source.jison'
+fileTypes: [
   'jison'
 ]
-'name': 'Jison'
-'patterns': [
+name: 'Jison'
+patterns: [
   {
-    'begin': '^(%%)$'                             # Has to be the first pattern
-    'comment': 'Match from first %% symbol to EOF'
-    'captures':
-      '0':
-        'name': 'meta.separator.section.jison'    # Match first %% symbol
-    'patterns': [
+    begin: '^(%%)$'                             # Has to be the first pattern
+    comment: 'Match from first %% symbol to EOF'
+    captures:
+      0:
+        name: 'meta.separator.section.jison'    # Match first %% symbol
+    patterns: [
       {
-        'begin': '^(%%)$'                         # Has to be the first pattern
-        'comment': 'Match from second %% symbol to EOF'
-        'captures':
-          '0':
-            'name': 'meta.separator.section.jison'# Match second %% symbol
-        'patterns': [
+        begin: '^(%%)$'                         # Has to be the first pattern
+        comment: 'Match from second %% symbol to EOF'
+        captures:
+          0:
+            name: 'meta.separator.section.jison'# Match second %% symbol
+        patterns: [
           {
-            'include': '#exceeding_sections'      # Has to be the first pattern
+            include: '#exceeding_sections'      # Has to be the first pattern
           }
           {
-            'include': '#third_section'
+            include: '#third_section'
           }
         ]
       }
       {
-        'include': '#second_section'
+        include: '#second_section'
       }
     ]
   }
   {
-    'include': '#first_section'
+    include: '#first_section'
   }
 ]
-'repository':
-  'first_section':
-    'patterns': [
+repository:
+  first_section:
+    patterns: [
       {
-        'begin': '(?!^%%$)'
-        'end': '(?=^%%$)'
-        'comment': 'Match the content of the first section'
-        'name': 'meta.section.first.jison'
-        'patterns': [
+        begin: '(?!^%%$)'
+        end: '(?=^%%$)'
+        comment: 'Match the content of the first section'
+        name: 'meta.section.first.jison'
+        patterns: [
           {
-            'include': '#prologue'
+            include: '#prologue'
           }
           {
-            'include': '#declarations'
+            include: '#declarations'
           }
           {
-            'include': '#comments'
-            'comment': 'jison supports Javascript comments'
+            include: '#comments'
+            comment: 'jison supports Javascript comments'
           }
         ]
       }
     ]
-  'second_section':
-    'patterns': [
+  second_section:
+    patterns: [
       {
-        'begin': '(?!^%%$)'
-        'end': '(?=^%%$)'
-        'comment': 'Match the content of the second section'
-        'name': 'meta.section.second.jison'
-        'patterns': [
+        begin: '(?!^%%$)'
+        end: '(?=^%%$)'
+        comment: 'Match the content of the second section'
+        name: 'meta.section.second.jison'
+        patterns: [
           {
-            'include': '#comments'
-            'comment': 'jison supports C/C++ comments'
+            include: '#comments'
+            comment: 'jison supports C/C++ comments'
           }
           {
-            'include': '#rules'
+            include: '#rules'
           }
         ]
       }
     ]
-  'third_section':
-    'patterns': [
+  third_section:
+    patterns: [
       {
-        'begin': '(?!^%%$)'
-        'end': '(?=^%%$)'
-        'comment': 'Match the content of the third section'
-        'name': 'meta.section.third.jison'
-        'patterns': [
+        begin: '(?!^%%$)'
+        end: '(?=^%%$)'
+        comment: 'Match the content of the third section'
+        name: 'meta.section.third.jison'
+        patterns: [
           {
-            'include': 'source.js'
-            'comment': 'Epilogue contains Javascript code only'
+            include: 'source.js'
+            comment: 'Epilogue contains Javascript code only'
           }
         ]
       }
     ]
-  'exceeding_sections':
-    'patterns': [
-      'begin': '^(%%)$'
-      'name': 'invalid.illegal.exceeding-sections.jison'
-      'comment': 'Match exceeding sections created by too many %% symbols'
+  exceeding_sections:
+    patterns: [
+      begin: '^(%%)$'
+      name: 'invalid.illegal.exceeding-sections.jison'
+      comment: 'Match exceeding sections created by too many %% symbols'
     ]
-  'prologue':
-    'patterns': [
-      'begin': '%{'
-      'end': '%}'
-      'comment': 'Match the prologues, first section only'
-      'name': 'meta.section.prologue'
-      'captures':
-        '0':
-          'name': 'meta.separator.prologue.jison' # Match %{ and %} symbols
-      'patterns': [
+  prologue:
+    patterns: [
+      begin: '%{'
+      end: '%}'
+      comment: 'Match the prologues, first section only'
+      name: 'meta.section.prologue'
+      captures:
+        0:
+          name: 'meta.separator.prologue.jison' # Match %{ and %} symbols
+      patterns: [
         {
-          'include': 'source.js'
-          'comment': 'Prologues contain Javascript code only'
+          include: 'source.js'
+          comment: 'Prologues contain Javascript code only'
         }
       ]
     ]
-  'declarations':
-    'patterns': [
+  declarations:
+    patterns: [
       {
-        'include': '#directives'
+        include: '#directives'
       }
       {
-        'include': '#types'
+        include: '#types'
       }
       {
-        'include': '#symbols'
+        include: '#symbols'
       }
       {
-        'include': '#numbers'
+        include: '#numbers'
       }
       {
-        'include': '#block'
+        include: '#block'
       }
       {
-        'include': '#strings'
+        include: '#strings'
       }
       {
-        'match': '\\;'
-        'comment': 'Semicolon can be only at the end of a union'
-        'name': 'punctuation.union-declaration.end.jison'
+        match: '\\;'
+        comment: 'Semicolon can be only at the end of a union'
+        name: 'punctuation.union-declaration.end.jison'
       }
     ]
-  'rules':
-    'patterns': [
+  rules:
+    patterns: [
       {
-        'begin': '([a-zA-Z_.\-][a-zA-Z_.\-0-9]*)[ \\t\\n\\r]*(:)'
-        'end': ';'
-        'beginCaptures':
-          '1':
-            'name': 'variable.grammar-rule.token-def.jison'
-            'comment': 'Match the result of the grammar rule'
-          '2':
-            'name': 'punctuation.grammar-rule.result-separator.jison'     # :
-        'endCaptures':
-          '0':
-            'name': 'punctuation.grammar-rule.end.jison'
-        'comment': 'Match grammar rules, second section only'
-        'name': 'meta.grammar-rule.jison'
-        'patterns': [
+        begin: '([a-zA-Z_.\-][a-zA-Z_.\-0-9]*)[ \\t\\n\\r]*(:)'
+        end: ';'
+        beginCaptures:
+          1:
+            name: 'variable.grammar-rule.token-def.jison'
+            comment: 'Match the result of the grammar rule'
+          2:
+            name: 'punctuation.grammar-rule.result-separator.jison'     # :
+        endCaptures:
+          0:
+            name: 'punctuation.grammar-rule.end.jison'
+        comment: 'Match grammar rules, second section only'
+        name: 'meta.grammar-rule.jison'
+        patterns: [
           {
-            'include': '#components'
+            include: '#components'
           }
         ]
       }
     ]
-  'components':
-    'patterns': [
+  components:
+    patterns: [
       {
-        'begin': '(?=([a-zA-Z_.\-][a-zA-Z_.\-0-9]*)?)'  # (?) Comp can be empty
-        'end': '\\||(?=;)'
-        'endCaptures':
-          '0':
-            'name': 'punctuation.grammar-rule.component-separator.jison'  # |
-        'comment': 'Match each component in a grammar rule'
-        'name': 'meta.section.component'
-        'patterns': [
+        begin: '(?=([a-zA-Z_.\-][a-zA-Z_.\-0-9]*)?)'  # (?) Comp can be empty
+        end: '\\||(?=;)'
+        endCaptures:
+          0:
+            name: 'punctuation.grammar-rule.component-separator.jison'  # |
+        comment: 'Match each component in a grammar rule'
+        name: 'meta.section.component'
+        patterns: [
           {
-            'include': '#comments'
-            'comment': 'Comments can be also inside grammar components'
+            include: '#comments'
+            comment: 'Comments can be also inside grammar components'
           }
           {
-            'begin': '\''
-            'beginCaptures':
-              '0':
-                'name': 'punctuation.definition.string.begin.jison'
-            'end': '\''
-            'endCaptures':
-              '0':
-                'name': 'punctuation.definition.string.end.jison'
-            'comment': 'Match single character tokens inside components'
-            'name': 'string.quoted.single.character-token.jison'
-            'patterns': [
+            begin: '\''
+            beginCaptures:
+              0:
+                name: 'punctuation.definition.string.begin.jison'
+            end: '\''
+            endCaptures:
+              0:
+                name: 'punctuation.definition.string.end.jison'
+            comment: 'Match single character tokens inside components'
+            name: 'string.quoted.single.character-token.jison'
+            patterns: [
               #TODO {
-              #  'include': '#string_escaped_char'
+              #  include: '#string_escaped_char'
               #}
               # {
-              #  'include': '#line_continuation_character'
+              #  include: '#line_continuation_character'
               #}
             ]
           }
           {
-            'include': '#directives'
+            include: '#directives'
           }
           {
-            'include': '#symbols'
+            include: '#symbols'
           }
           {
-            'include': '#actions'
+            include: '#actions'
           }
         ]
       }
     ]
-  'directives':
-    'patterns': [
+  directives:
+    patterns: [
       {
-        'match': '%[a-z\-]+'
-        'comment': 'Match %-directives'
-        'name': 'keyword.control.directive.jison'
+        match: '%[a-z\-]+'
+        comment: 'Match %-directives'
+        name: 'keyword.control.directive.jison'
       }
     ]
-  'symbols':
-    'patterns': [
+  symbols:
+    patterns: [
       {
-        'match': '[a-zA-Z_.\-][a-zA-Z_.\-0-9]*'
-        'comment': 'Match valid symbols'
-        'name': 'variable.grammar-rule.token-type.jison'
+        match: '[a-zA-Z_.\-][a-zA-Z_.\-0-9]*'
+        comment: 'Match valid symbols'
+        name: 'variable.grammar-rule.token-type.jison'
       }
     ]
-  'types':
-    'patterns': [
+  types:
+    patterns: [
       {
-        'begin': '<'
-        'end': '>'
-        'beginCaptures':
-          '0':
-            'name': 'punctuation.type-declaration.begin.jison'
-        'endCaptures':
-          '0':
-            'name': 'punctuation.type-declaration.end.jison'
-        'comment': 'Match type declarations'
-        'patterns': [
+        begin: '<'
+        end: '>'
+        beginCaptures:
+          0:
+            name: 'punctuation.type-declaration.begin.jison'
+        endCaptures:
+          0:
+            name: 'punctuation.type-declaration.end.jison'
+        comment: 'Match type declarations'
+        patterns: [
           {
-            'match': '[$a-zA-Z\_][$a-zA-Z0-9\_]*'
-            'comment': 'A valid JS identifier'
+            match: '[$a-zA-Z\_][$a-zA-Z0-9\_]*'
+            comment: 'A valid JS identifier'
           }
         ]
       }
     ]
-  'actions':
-    'patterns': [
+  actions:
+    patterns: [
       {
-        'begin': '\\{'
-        'beginCaptures':
-          '0':
-            'name': 'punctuation.action.begin.jison'
-        'end': '\\}'
-        'endCaptures':
-          '0':
-            'name': 'punctuation.action.end.jison'
-        'name': 'meta.action.jison'
-        'comment': 'Match action blocks associated with grammar rules'
-        'patterns': [
+        begin: '\\{'
+        beginCaptures:
+          0:
+            name: 'punctuation.action.begin.jison'
+        end: '\\}'
+        endCaptures:
+          0:
+            name: 'punctuation.action.end.jison'
+        name: 'meta.action.jison'
+        comment: 'Match action blocks associated with grammar rules'
+        patterns: [
           # TODO: Patterns for $-variable go here, or inside block_innards
           {
-            'include': 'source.js'
+            include: 'source.js'
           }
           {
-            'match': '\\$[$a-zA-Z\_][$a-zA-Z0-9\_]*',
-            'name': 'variable.interpolation.grammar-rule.jison',
-            'comment': 'A grammar rule variable reference.'
+            match: '\\$[$a-zA-Z\_][$a-zA-Z0-9\_]*',
+            name: 'variable.interpolation.grammar-rule.jison',
+            comment: 'A grammar rule variable reference.'
           }
         ]
       }
     ]
-  'comments':
-    'patterns': [
+  comments:
+    patterns: [
       {
-        'name': 'comment.line.double-slash.jison'
-        'match': '//.*$'
+        name: 'comment.line.double-slash.jison'
+        match: '//.*$'
       }
       {
-        'contentName': 'comment.block.jison'
-        'begin': '/\\*'
-        'end': '\\*/'
-        'captures':
-          '0':
-            'name': 'punctuation.definition.comment.jison'
-      }
-    ]
-  'numbers':
-    'patterns': [
-      {
-        'match': '\\b((0(x|X)[0-9a-fA-F]*)|(([0-9]+\\.?[0-9]*)|(\\.[0-9]+))((e|E)(\\+|-)?[0-9]+)?)(L|l|UL|ul|u|U|F|f|ll|LL|ull|ULL)?\\b'
-        'name': 'constant.numeric.c'
+        contentName: 'comment.block.jison'
+        begin: '/\\*'
+        end: '\\*/'
+        captures:
+          0:
+            name: 'punctuation.definition.comment.jison'
       }
     ]
-  'block':
-    'patterns': [
+  numbers:
+    patterns: [
       {
-        'begin': '\\{'
-        'beginCaptures':
-          '0':
-            'name': 'punctuation.section.block.begin.c'
-        'end': '\\}|(?=\\s*#\\s*endif\\b)'
-        'endCaptures':
-          '0':
-            'name': 'punctuation.section.block.end.c'
-        'name': 'meta.block.c'
-        'patterns': [
+        match: '\\b((0(x|X)[0-9a-fA-F]*)|(([0-9]+\\.?[0-9]*)|(\\.[0-9]+))((e|E)(\\+|-)?[0-9]+)?)(L|l|UL|ul|u|U|F|f|ll|LL|ull|ULL)?\\b'
+        name: 'constant.numeric.c'
+      }
+    ]
+  block:
+    patterns: [
+      {
+        begin: '\\{'
+        beginCaptures:
+          0:
+            name: 'punctuation.section.block.begin.c'
+        end: '\\}|(?=\\s*#\\s*endif\\b)'
+        endCaptures:
+          0:
+            name: 'punctuation.section.block.end.c'
+        name: 'meta.block.c'
+        patterns: [
           {
-            'include': 'source.js'
+            include: 'source.js'
           }
         ]
       }

--- a/grammars/jison.cson
+++ b/grammars/jison.cson
@@ -356,8 +356,14 @@ repository:
   numbers:
     patterns: [
       {
-        match: "\\b((0(x|X)[0-9a-fA-F]*)|(([0-9]+\\.?[0-9]*)|(\\.[0-9]+))((e|E)(\\+|-)?[0-9]+)?)(L|l|UL|ul|u|U|F|f|ll|LL|ull|ULL)?\\b"
-        name: "constant.numeric.c"
+        match: "(0[Xx])(\\h+)"
+        captures:
+          1: name: "storage.type.number.jison"
+          2: name: "constant.numeric.integer.hexadecimal.jison"
+      }
+      {
+        name:  "constant.numeric.integer.decimal.jison"
+        match: "\\d+"
       }
     ]
 

--- a/grammars/jison.cson
+++ b/grammars/jison.cson
@@ -43,38 +43,38 @@ patterns: [
 
 repository:
   declarations_section:
-        patterns: [
-          {
-            include: "#prologue"
-          }
-          {
-            include: "#declarations"
-          }
-          {
-            include: "#comments"
-            comment: "jison supports Javascript comments"
-          }
-        ]
+    patterns: [
+      {
+        include: "#prologue"
+      }
+      {
+        include: "#declarations"
+      }
+      {
+        include: "#comments"
+        comment: "jison supports Javascript comments"
+      }
+    ]
 
   rules_section:
-        patterns: [
-          {
-            include: "#comments"
-            comment: "jison supports C/C++ comments"
-          }
-          {include: "#actions"}
-          {
-            include: "#rules"
-          }
-        ]
+    patterns: [
+      {
+        include: "#comments"
+        comment: "jison supports C/C++ comments"
+      }
+      {include: "#actions"}
+      {
+        include: "#rules"
+      }
+    ]
 
   epilogue_section:
-        patterns: [
-          {
-            include: "source.js"
-            comment: "Epilogue contains Javascript code only"
-          }
-        ]
+    patterns: [
+      {
+        include: "source.js"
+        comment: "Epilogue contains Javascript code only"
+      }
+    ]
 
 
   prologue:

--- a/grammars/jison.cson
+++ b/grammars/jison.cson
@@ -44,6 +44,8 @@ patterns: [
 repository:
   declarations_section:
     patterns: [
+      {include: "#comments"}
+
       {
         name:  "meta.section.prologue.jison"
         begin: "(?=%\\{)"
@@ -54,18 +56,11 @@ repository:
       {
         include: "#declarations"
       }
-      {
-        include: "#comments"
-        comment: "jison supports Javascript comments"
-      }
     ]
 
   rules_section:
     patterns: [
-      {
-        include: "#comments"
-        comment: "jison supports C/C++ comments"
-      }
+      {include: "#comments"}
       {include: "#actions"}
       {
         include: "#rules"
@@ -124,6 +119,7 @@ repository:
         comment: "Match grammar rules, second section only"
         name: "meta.grammar-rule.jison"
         patterns: [
+          {include: "#comments"}
           {
             include: "#components"
           }
@@ -141,10 +137,7 @@ repository:
         comment: "Match each component in a grammar rule"
         name: "meta.section.component.jison"
         patterns: [
-          {
-            include: "#comments"
-            comment: "Comments can be also inside grammar components"
-          }
+          {include: "#comments"}
           {
             begin: "'"
             beginCaptures:
@@ -264,18 +257,19 @@ repository:
   comments:
     patterns: [
       {
-        name: "comment.line.double-slash.jison"
-        match: "//.*$"
-      }
-      {
-        contentName: "comment.block.jison"
+        name:  "comment.line.double-slash.jison"
+        begin: "//"
+        end:   "(?=\\n)"
+        beginCaptures: 0: name: "punctuation.definition.comment.jison"
+      },{
+        name:  "comment.block.jison"
         begin: "/\\*"
-        end: "\\*/"
-        captures:
-          0:
-            name: "punctuation.definition.comment.jison"
+        end:   "\\*/"
+        beginCaptures: 0: name: "punctuation.definition.comment.begin.jison"
+        endCaptures:   0: name: "punctuation.definition.comment.end.jison"
       }
     ]
+
   numbers:
     patterns: [
       {

--- a/grammars/jison.cson
+++ b/grammars/jison.cson
@@ -19,30 +19,30 @@ patterns: [
             name: "meta.separator.section.jison"# Match second %% symbol
         patterns: [
           {
-            include: "#exceeding_sections"      # Has to be the first pattern
-          }
-          {
-            include: "#third_section"
+            name:  "meta.section.epilogue.jison"
+            begin: "(?!%%)"
+            patterns: [include: "#epilogue_section"]
           }
         ]
       }
       {
-        include: "#second_section"
+        name:  "meta.section.rules.jison"
+        begin: "(?!%%)"
+        end:   "(?=%%)"
+        patterns: [include: "#rules_section"]
       }
     ]
   }
   {
-    include: "#first_section"
+    name:  "meta.section.declarations.jison"
+    begin: "(?!%%)"
+    end:   "(?=%%)"
+    patterns: [include: "#declarations_section"]
   }
 ]
+
 repository:
-  first_section:
-    patterns: [
-      {
-        begin: "(?!^%%$)"
-        end: "(?=^%%$)"
-        comment: "Match the content of the first section"
-        name: "meta.section.declarations.jison"
+  declarations_section:
         patterns: [
           {
             include: "#prologue"
@@ -55,15 +55,8 @@ repository:
             comment: "jison supports Javascript comments"
           }
         ]
-      }
-    ]
-  second_section:
-    patterns: [
-      {
-        begin: "(?!^%%$)"
-        end: "(?=^%%$)"
-        comment: "Match the content of the second section"
-        name: "meta.section.rules.jison"
+
+  rules_section:
         patterns: [
           {
             include: "#comments"
@@ -74,29 +67,16 @@ repository:
             include: "#rules"
           }
         ]
-      }
-    ]
-  third_section:
-    patterns: [
-      {
-        begin: "(?!^%%$)"
-        end: "(?=^%%$)"
-        comment: "Match the content of the third section"
-        name: "meta.section.epilogue.jison"
+
+  epilogue_section:
         patterns: [
           {
             include: "source.js"
             comment: "Epilogue contains Javascript code only"
           }
         ]
-      }
-    ]
-  exceeding_sections:
-    patterns: [
-      begin: "^(%%)$"
-      name: "invalid.illegal.exceeding-sections.jison"
-      comment: "Match exceeding sections created by too many %% symbols"
-    ]
+
+
   prologue:
     patterns: [
       begin: "%{"

--- a/grammars/jison.cson
+++ b/grammars/jison.cson
@@ -1,58 +1,58 @@
-scopeName: 'source.jison'
+scopeName: "source.jison"
 fileTypes: [
-  'jison'
+  "jison"
 ]
-name: 'Jison'
+name: "Jison"
 patterns: [
   {
-    begin: '^(%%)$'                             # Has to be the first pattern
-    comment: 'Match from first %% symbol to EOF'
+    begin: "^(%%)$"                             # Has to be the first pattern
+    comment: "Match from first %% symbol to EOF"
     captures:
       0:
-        name: 'meta.separator.section.jison'    # Match first %% symbol
+        name: "meta.separator.section.jison"    # Match first %% symbol
     patterns: [
       {
-        begin: '^(%%)$'                         # Has to be the first pattern
-        comment: 'Match from second %% symbol to EOF'
+        begin: "^(%%)$"                         # Has to be the first pattern
+        comment: "Match from second %% symbol to EOF"
         captures:
           0:
-            name: 'meta.separator.section.jison'# Match second %% symbol
+            name: "meta.separator.section.jison"# Match second %% symbol
         patterns: [
           {
-            include: '#exceeding_sections'      # Has to be the first pattern
+            include: "#exceeding_sections"      # Has to be the first pattern
           }
           {
-            include: '#third_section'
+            include: "#third_section"
           }
         ]
       }
       {
-        include: '#second_section'
+        include: "#second_section"
       }
     ]
   }
   {
-    include: '#first_section'
+    include: "#first_section"
   }
 ]
 repository:
   first_section:
     patterns: [
       {
-        begin: '(?!^%%$)'
-        end: '(?=^%%$)'
-        comment: 'Match the content of the first section'
-        name: 'meta.section.first.jison'
+        begin: "(?!^%%$)"
+        end: "(?=^%%$)"
+        comment: "Match the content of the first section"
+        name: "meta.section.first.jison"
         patterns: [
           {
-            include: '#prologue'
+            include: "#prologue"
           }
           {
-            include: '#declarations'
+            include: "#declarations"
           }
           {
-            include: '#comments'
-            comment: 'jison supports Javascript comments'
+            include: "#comments"
+            comment: "jison supports Javascript comments"
           }
         ]
       }
@@ -60,17 +60,17 @@ repository:
   second_section:
     patterns: [
       {
-        begin: '(?!^%%$)'
-        end: '(?=^%%$)'
-        comment: 'Match the content of the second section'
-        name: 'meta.section.second.jison'
+        begin: "(?!^%%$)"
+        end: "(?=^%%$)"
+        comment: "Match the content of the second section"
+        name: "meta.section.second.jison"
         patterns: [
           {
-            include: '#comments'
-            comment: 'jison supports C/C++ comments'
+            include: "#comments"
+            comment: "jison supports C/C++ comments"
           }
           {
-            include: '#rules'
+            include: "#rules"
           }
         ]
       }
@@ -78,85 +78,85 @@ repository:
   third_section:
     patterns: [
       {
-        begin: '(?!^%%$)'
-        end: '(?=^%%$)'
-        comment: 'Match the content of the third section'
-        name: 'meta.section.third.jison'
+        begin: "(?!^%%$)"
+        end: "(?=^%%$)"
+        comment: "Match the content of the third section"
+        name: "meta.section.third.jison"
         patterns: [
           {
-            include: 'source.js'
-            comment: 'Epilogue contains Javascript code only'
+            include: "source.js"
+            comment: "Epilogue contains Javascript code only"
           }
         ]
       }
     ]
   exceeding_sections:
     patterns: [
-      begin: '^(%%)$'
-      name: 'invalid.illegal.exceeding-sections.jison'
-      comment: 'Match exceeding sections created by too many %% symbols'
+      begin: "^(%%)$"
+      name: "invalid.illegal.exceeding-sections.jison"
+      comment: "Match exceeding sections created by too many %% symbols"
     ]
   prologue:
     patterns: [
-      begin: '%{'
-      end: '%}'
-      comment: 'Match the prologues, first section only'
-      name: 'meta.section.prologue'
+      begin: "%{"
+      end: "%}"
+      comment: "Match the prologues, first section only"
+      name: "meta.section.prologue"
       captures:
         0:
-          name: 'meta.separator.prologue.jison' # Match %{ and %} symbols
+          name: "meta.separator.prologue.jison" # Match %{ and %} symbols
       patterns: [
         {
-          include: 'source.js'
-          comment: 'Prologues contain Javascript code only'
+          include: "source.js"
+          comment: "Prologues contain Javascript code only"
         }
       ]
     ]
   declarations:
     patterns: [
       {
-        include: '#directives'
+        include: "#directives"
       }
       {
-        include: '#types'
+        include: "#types"
       }
       {
-        include: '#symbols'
+        include: "#symbols"
       }
       {
-        include: '#numbers'
+        include: "#numbers"
       }
       {
-        include: '#block'
+        include: "#block"
       }
       {
-        include: '#strings'
+        include: "#strings"
       }
       {
-        match: '\\;'
-        comment: 'Semicolon can be only at the end of a union'
-        name: 'punctuation.union-declaration.end.jison'
+        match: "\\;"
+        comment: "Semicolon can be only at the end of a union"
+        name: "punctuation.union-declaration.end.jison"
       }
     ]
   rules:
     patterns: [
       {
-        begin: '([a-zA-Z_.\-][a-zA-Z_.\-0-9]*)[ \\t\\n\\r]*(:)'
-        end: ';'
+        begin: "([a-zA-Z_.\-][a-zA-Z_.\-0-9]*)[ \\t\\n\\r]*(:)"
+        end: ";"
         beginCaptures:
           1:
-            name: 'variable.grammar-rule.token-def.jison'
-            comment: 'Match the result of the grammar rule'
+            name: "variable.grammar-rule.token-def.jison"
+            comment: "Match the result of the grammar rule"
           2:
-            name: 'punctuation.grammar-rule.result-separator.jison'     # :
+            name: "punctuation.grammar-rule.result-separator.jison"     # :
         endCaptures:
           0:
-            name: 'punctuation.grammar-rule.end.jison'
-        comment: 'Match grammar rules, second section only'
-        name: 'meta.grammar-rule.jison'
+            name: "punctuation.grammar-rule.end.jison"
+        comment: "Match grammar rules, second section only"
+        name: "meta.grammar-rule.jison"
         patterns: [
           {
-            include: '#components'
+            include: "#components"
           }
         ]
       }
@@ -164,46 +164,46 @@ repository:
   components:
     patterns: [
       {
-        begin: '(?=([a-zA-Z_.\-][a-zA-Z_.\-0-9]*)?)'  # (?) Comp can be empty
-        end: '\\||(?=;)'
+        begin: "(?=([a-zA-Z_.\-][a-zA-Z_.\-0-9]*)?)"  # (?) Comp can be empty
+        end: "\\||(?=;)"
         endCaptures:
           0:
-            name: 'punctuation.grammar-rule.component-separator.jison'  # |
-        comment: 'Match each component in a grammar rule'
-        name: 'meta.section.component'
+            name: "punctuation.grammar-rule.component-separator.jison"  # |
+        comment: "Match each component in a grammar rule"
+        name: "meta.section.component"
         patterns: [
           {
-            include: '#comments'
-            comment: 'Comments can be also inside grammar components'
+            include: "#comments"
+            comment: "Comments can be also inside grammar components"
           }
           {
-            begin: '\''
+            begin: "'"
             beginCaptures:
               0:
-                name: 'punctuation.definition.string.begin.jison'
-            end: '\''
+                name: "punctuation.definition.string.begin.jison"
+            end: "'"
             endCaptures:
               0:
-                name: 'punctuation.definition.string.end.jison'
-            comment: 'Match single character tokens inside components'
-            name: 'string.quoted.single.character-token.jison'
+                name: "punctuation.definition.string.end.jison"
+            comment: "Match single character tokens inside components"
+            name: "string.quoted.single.character-token.jison"
             patterns: [
               #TODO {
-              #  include: '#string_escaped_char'
+              #  include: "#string_escaped_char"
               #}
               # {
-              #  include: '#line_continuation_character'
+              #  include: "#line_continuation_character"
               #}
             ]
           }
           {
-            include: '#directives'
+            include: "#directives"
           }
           {
-            include: '#symbols'
+            include: "#symbols"
           }
           {
-            include: '#actions'
+            include: "#actions"
           }
         ]
       }
@@ -211,35 +211,35 @@ repository:
   directives:
     patterns: [
       {
-        match: '%[a-z\-]+'
-        comment: 'Match %-directives'
-        name: 'keyword.control.directive.jison'
+        match: "%[a-z\-]+"
+        comment: "Match %-directives"
+        name: "keyword.control.directive.jison"
       }
     ]
   symbols:
     patterns: [
       {
-        match: '[a-zA-Z_.\-][a-zA-Z_.\-0-9]*'
-        comment: 'Match valid symbols'
-        name: 'variable.grammar-rule.token-type.jison'
+        match: "[a-zA-Z_.\-][a-zA-Z_.\-0-9]*"
+        comment: "Match valid symbols"
+        name: "variable.grammar-rule.token-type.jison"
       }
     ]
   types:
     patterns: [
       {
-        begin: '<'
-        end: '>'
+        begin: "<"
+        end: ">"
         beginCaptures:
           0:
-            name: 'punctuation.type-declaration.begin.jison'
+            name: "punctuation.type-declaration.begin.jison"
         endCaptures:
           0:
-            name: 'punctuation.type-declaration.end.jison'
-        comment: 'Match type declarations'
+            name: "punctuation.type-declaration.end.jison"
+        comment: "Match type declarations"
         patterns: [
           {
-            match: '[$a-zA-Z\_][$a-zA-Z0-9\_]*'
-            comment: 'A valid JS identifier'
+            match: "[$a-zA-Z\_][$a-zA-Z0-9\_]*"
+            comment: "A valid JS identifier"
           }
         ]
       }
@@ -247,25 +247,25 @@ repository:
   actions:
     patterns: [
       {
-        begin: '\\{'
+        begin: "\\{"
         beginCaptures:
           0:
-            name: 'punctuation.action.begin.jison'
-        end: '\\}'
+            name: "punctuation.action.begin.jison"
+        end: "\\}"
         endCaptures:
           0:
-            name: 'punctuation.action.end.jison'
-        name: 'meta.action.jison'
-        comment: 'Match action blocks associated with grammar rules'
+            name: "punctuation.action.end.jison"
+        name: "meta.action.jison"
+        comment: "Match action blocks associated with grammar rules"
         patterns: [
           # TODO: Patterns for $-variable go here, or inside block_innards
           {
-            include: 'source.js'
+            include: "source.js"
           }
           {
-            match: '\\$[$a-zA-Z\_][$a-zA-Z0-9\_]*',
-            name: 'variable.interpolation.grammar-rule.jison',
-            comment: 'A grammar rule variable reference.'
+            match: "\\$[$a-zA-Z\_][$a-zA-Z0-9\_]*",
+            name: "variable.interpolation.grammar-rule.jison",
+            comment: "A grammar rule variable reference."
           }
         ]
       }
@@ -273,40 +273,40 @@ repository:
   comments:
     patterns: [
       {
-        name: 'comment.line.double-slash.jison'
-        match: '//.*$'
+        name: "comment.line.double-slash.jison"
+        match: "//.*$"
       }
       {
-        contentName: 'comment.block.jison'
-        begin: '/\\*'
-        end: '\\*/'
+        contentName: "comment.block.jison"
+        begin: "/\\*"
+        end: "\\*/"
         captures:
           0:
-            name: 'punctuation.definition.comment.jison'
+            name: "punctuation.definition.comment.jison"
       }
     ]
   numbers:
     patterns: [
       {
-        match: '\\b((0(x|X)[0-9a-fA-F]*)|(([0-9]+\\.?[0-9]*)|(\\.[0-9]+))((e|E)(\\+|-)?[0-9]+)?)(L|l|UL|ul|u|U|F|f|ll|LL|ull|ULL)?\\b'
-        name: 'constant.numeric.c'
+        match: "\\b((0(x|X)[0-9a-fA-F]*)|(([0-9]+\\.?[0-9]*)|(\\.[0-9]+))((e|E)(\\+|-)?[0-9]+)?)(L|l|UL|ul|u|U|F|f|ll|LL|ull|ULL)?\\b"
+        name: "constant.numeric.c"
       }
     ]
   block:
     patterns: [
       {
-        begin: '\\{'
+        begin: "\\{"
         beginCaptures:
           0:
-            name: 'punctuation.section.block.begin.c'
-        end: '\\}|(?=\\s*#\\s*endif\\b)'
+            name: "punctuation.section.block.begin.c"
+        end: "\\}|(?=\\s*#\\s*endif\\b)"
         endCaptures:
           0:
-            name: 'punctuation.section.block.end.c'
-        name: 'meta.block.c'
+            name: "punctuation.section.block.end.c"
+        name: "meta.block.c"
         patterns: [
           {
-            include: 'source.js'
+            include: "source.js"
           }
         ]
       }

--- a/grammars/jison.cson
+++ b/grammars/jison.cson
@@ -101,7 +101,7 @@ repository:
       begin: "%{"
       end: "%}"
       comment: "Match the prologues, first section only"
-      name: "meta.section.prologue"
+      name: "meta.section.prologue.jison"
       captures:
         0:
           name: "meta.separator.prologue.jison" # Match %{ and %} symbols
@@ -170,7 +170,7 @@ repository:
           0:
             name: "punctuation.grammar-rule.component-separator.jison"  # |
         comment: "Match each component in a grammar rule"
-        name: "meta.section.component"
+        name: "meta.section.component.jison"
         patterns: [
           {
             include: "#comments"

--- a/grammars/jison.cson
+++ b/grammars/jison.cson
@@ -2,6 +2,17 @@
 scopeName: "source.jison"
 fileTypes: ["jison"]
 
+# This grammar is based on the Jison files from
+# https://github.com/zaach/ebnf-parser and
+# https://github.com/GerHobbelt/ebnf-parser. The original Jison allows
+# identifiers to contain (and end with) hyphens. GerHobbelt Jison makes a
+# distinction between identifiers, which can’t contain hyphens at all, and
+# names, which can contain (but *not* end with) hyphens. As a compromise, this
+# grammar uses
+#   [\p{Alpha}_](?:[\w-]*\w)?
+# to match both identifiers and names. This means that identifiers can contain
+# hyphens, even when they’re not allowed in GerHobbelt Jison.
+
 patterns: [
   {
     # Like Bison
@@ -274,7 +285,7 @@ repository:
     patterns: [
       {include: "#actions"}
       {
-        name: "meta.action.jison"
+        name:  "meta.action.jison"
         begin: "\\{"
         end:   "\\}"
         beginCaptures: 0: name: "punctuation.definition.action.begin.jison"

--- a/grammars/jison.cson
+++ b/grammars/jison.cson
@@ -188,7 +188,62 @@ repository:
       {include: "#actions"}
       {include: "#include_declarations"}
       {
-        include: "#rules"
+        name:  "meta.grammar-rule.jison"
+        begin: "\\b[\\p{Alpha}_](?:[\\w-]*\\w)?\\b"
+        end:   ";"
+        beginCaptures: 0: name: "variable.grammar-rule.token-def.jison"
+        endCaptures:   0: name: "punctuation.terminator.grammar-rule.jison"
+        patterns: [
+          {include: "#comments"}
+          {
+            name:  "meta.rule-components.jison"
+            begin: ":"
+            end:   "(?=;)"
+            beginCaptures: 0: name: "keyword.operator.rule-components.assignment.jison"
+            patterns: [
+              {include: "#comments"}
+              {include: "#quoted_strings"}
+              {
+                match: "(\\[)([\\p{Alpha}_](?:[\\w-]*\\w)?)(\\])"
+                captures:
+                  1: name: "punctuation.definition.named-reference.begin.jison"
+                  2: name: "entity.name.other.reference.jison"
+                  3: name: "punctuation.definition.named-reference.end.jison"
+              },{
+                name:  "meta.prec.jison"
+                begin: "(%(prec))\\s*"
+                end:   "(?<=['\"])|(?=\\s)"
+                beginCaptures: 1: name: "keyword.other.$2.jison"
+                patterns: [
+                  {include: "#comments"}
+                  {include: "#quoted_strings"}
+                  {
+                    name:  "constant.other.token.jison"
+                    begin: "(?=\\S)"
+                    end:   "(?=\\s)"
+                  }
+                ]
+              },{
+                name:  "keyword.operator.rule-components.separator.jison"
+                match: "\\|"
+              },{
+                name:  "keyword.other.$0.jison"
+                match: "\\berror\\b"
+              },{
+                # In addition to Bison’s %empty
+                # (https://www.gnu.org/software/bison/manual/html_node/Empty-Rules.html),
+                # GerHobbelt Jison supports %epsilon, ε (U+03B5 GREEK SMALL
+                # LETTER EPSILON), and these variants of the epsilon character:
+                # Ɛ U+0190 LATIN CAPITAL LETTER OPEN E
+                # ɛ U+0250 LATIN SMALL LETTER OPEN E
+                # ϵ U+03F5 GREEK LUNATE EPSILON SYMBOL
+                name:  "keyword.other.empty.jison"
+                match: "(?:%(?:e(?:mpty|psilon))|\\b[\u0190\u025B\u03B5\u03F5])\\b"
+              }
+              {include: "#rule_actions"}
+            ]
+          }
+        ]
       }
     ]
 
@@ -198,111 +253,6 @@ repository:
       {include: "source.js"}
     ]
 
-
-  rules:
-    patterns: [
-      {
-        begin: "([a-zA-Z_.\-][a-zA-Z_.\-0-9]*)[ \\t\\n\\r]*(:)"
-        end: ";"
-        beginCaptures:
-          1:
-            name: "variable.grammar-rule.token-def.jison"
-            comment: "Match the result of the grammar rule"
-          2:
-            name: "punctuation.grammar-rule.result-separator.jison"     # :
-        endCaptures:
-          0:
-            name: "punctuation.grammar-rule.end.jison"
-        comment: "Match grammar rules, second section only"
-        name: "meta.grammar-rule.jison"
-        patterns: [
-          {include: "#comments"}
-          {
-            include: "#components"
-          }
-        ]
-      }
-    ]
-  components:
-    patterns: [
-      {
-        begin: "(?=([a-zA-Z_.\-][a-zA-Z_.\-0-9]*)?)"  # (?) Comp can be empty
-        end: "\\||(?=;)"
-        endCaptures:
-          0:
-            name: "punctuation.grammar-rule.component-separator.jison"  # |
-        comment: "Match each component in a grammar rule"
-        name: "meta.section.component.jison"
-        patterns: [
-          {include: "#comments"}
-          {
-            begin: "'"
-            beginCaptures:
-              0:
-                name: "punctuation.definition.string.begin.jison"
-            end: "'"
-            endCaptures:
-              0:
-                name: "punctuation.definition.string.end.jison"
-            comment: "Match single character tokens inside components"
-            name: "string.quoted.single.character-token.jison"
-            patterns: [
-              #TODO {
-              #  include: "#string_escaped_char"
-              #}
-              # {
-              #  include: "#line_continuation_character"
-              #}
-            ]
-          }
-          {
-            include: "#directives"
-          }
-          {
-            include: "#symbols"
-          }
-          {
-            include: "#rule_actions"
-          }
-        ]
-      }
-    ]
-  directives:
-    patterns: [
-      {
-        match: "%[a-z\-]+"
-        comment: "Match %-directives"
-        name: "keyword.control.directive.jison"
-      }
-    ]
-  symbols:
-    patterns: [
-      {
-        match: "[a-zA-Z_.\-][a-zA-Z_.\-0-9]*"
-        comment: "Match valid symbols"
-        name: "variable.grammar-rule.token-type.jison"
-      }
-    ]
-  types:
-    patterns: [
-      {
-        begin: "<"
-        end: ">"
-        beginCaptures:
-          0:
-            name: "punctuation.type-declaration.begin.jison"
-        endCaptures:
-          0:
-            name: "punctuation.type-declaration.end.jison"
-        comment: "Match type declarations"
-        patterns: [
-          {
-            match: "[$a-zA-Z\_][$a-zA-Z0-9\_]*"
-            comment: "A valid JS identifier"
-          }
-        ]
-      }
-    ]
 
   actions:
     patterns: [
@@ -452,26 +402,6 @@ repository:
         begin: "'"
         end:   "'"
         patterns: [include: "source.js#string_escapes"]
-      }
-    ]
-
-  block:
-    patterns: [
-      {
-        begin: "\\{"
-        beginCaptures:
-          0:
-            name: "punctuation.section.block.begin.c"
-        end: "\\}|(?=\\s*#\\s*endif\\b)"
-        endCaptures:
-          0:
-            name: "punctuation.section.block.end.c"
-        name: "meta.block.c"
-        patterns: [
-          {
-            include: "source.js"
-          }
-        ]
       }
     ]
 

--- a/grammars/jisonlex-injection.cson
+++ b/grammars/jisonlex-injection.cson
@@ -1,0 +1,28 @@
+"name": "Jison Lex Injection"
+scopeName: "source.jisonlex-injection"
+
+# Jison Lex replaces certain strings that start with “yy”:
+#
+# This string | is replaced with
+# ------------|-----------------
+# yyleng      | yy_.yyleng
+# yylineno    | yy_.yylineno
+# yylloc      | yy_.yylloc
+# yytext      | yy_.yytext
+#
+# This replacement even occurs in comments and JavaScript strings, but it seems
+# unnecessary to highlight these strings in comments. Replacing
+#   "L:meta.rule.action.jisonlex -comment"
+# with
+#   "L:meta.rule.action.jisonlex -(comment | string), source.js.embedded.source"
+# will eliminate highlighting in strings, but something like
+#  `${"yytext"}`
+# will still not be highlighted correctly. The L: prefix makes sure that things
+# like the “yylloc” in “yylloc.first_line”.
+injectionSelector: "L:meta.rule.action.jisonlex -comment"
+patterns: [
+  {
+    name:  "variable.language.jisonlex"
+    match: "\\byy(?:l(?:eng|ineno|loc)|text)\\b"
+  }
+]

--- a/grammars/jisonlex-injection.cson
+++ b/grammars/jisonlex-injection.cson
@@ -18,7 +18,7 @@ scopeName: "source.jisonlex-injection"
 # will eliminate highlighting in strings, but something like
 #  `${"yytext"}`
 # will still not be highlighted correctly. The L: prefix makes sure that things
-# like the “yylloc” in “yylloc.first_line”.
+# like the “yylloc” in “yylloc.first_line” are highlighted correctly.
 injectionSelector: "L:meta.rule.action.jisonlex -comment"
 patterns: [
   {

--- a/grammars/jisonlex.cson
+++ b/grammars/jisonlex.cson
@@ -81,30 +81,10 @@ repository:
           }
         ]
       }
+      {include: "source.jison#options_declarations"}
       {
-        begin: "^(%option)\\s(?=\\S)"
-        beginCaptures:
-          1:
-            name: "keyword.other.option.jisonlex"
-        end: "$"
-        name: "meta.options.jisonlex"
-        patterns: [
-          {
-            match: "\\b(?:(?:no)?(?:[78]bit|align|backup|batch|c\\+\\+|debug|default|ecs|fast|full|interactive|lex-compat|meta-ecs|perf-report|read|stdout|verbose|warn|array|pointer|input|unput|yy_(?:(?:push|pop|top)_state|scan_(?:buffer|bytes|string))|main|stack|stdinit|yylineno|yywrap)|(?:case(?:ful|less)|case-(?:in)?sensitive|(?:always|never)-interactive))\\b"
-            name: "support.other.option.jisonlex"
-          }
-        ]
-      }
-      {
-        begin: "^%(?:array|pointer)"
-        end: "$"
-        name: "keyword.other.option.jisonlex"
-        patterns: [
-          {
-            match: "\\S"
-            name: "invalid.illegal.jisonlex"
-          }
-        ]
+        name:  "invalid.unimplemented.jisonlex"
+        match: "%(?:array|pointer)"
       }
       {include: "source.jison#user_code_blocks"}
     ]

--- a/grammars/jisonlex.cson
+++ b/grammars/jisonlex.cson
@@ -1,8 +1,8 @@
+"name": "Jison Lex"
 scopeName: "source.jisonlex"
 fileTypes: [
   "jisonlex"
 ]
-name: "Jison Lex"
 patterns: [
   {
     begin: "\\A(?!%%$)"

--- a/grammars/jisonlex.cson
+++ b/grammars/jisonlex.cson
@@ -9,6 +9,38 @@ patterns: [
     comment: "first section of the file - definitions"
     end: "^(?=%%$)"
     name: "meta.section.definitions.jisonlex"
+    patterns: [include: "#definitions_section"]
+  }
+  {
+    begin: "^(%%)$"
+    beginCaptures:
+      1:
+        name: "punctuation.separator.sections.jisonlex"
+    end: "\\Z.\\A(?# never end)"
+    patterns: [
+      {
+        begin: "^(?!%%$)"
+        comment: "second section of the file - rules"
+        end: "^(?=%%$)"
+        name: "meta.section.rules.jisonlex"
+        patterns: [include: "#rules_section"]
+      }
+      {
+        begin: "^(%%)$"
+        beginCaptures:
+          1:
+            name: "punctuation.separator.sections.jisonlex"
+        comment: "third section of the file - user code"
+        contentName: "meta.section.user-code.jisonlex"
+        end: "\\Z.\\A(?# never end)"
+        patterns: [include: "#user_code_section"]
+      }
+    ]
+  }
+]
+
+repository:
+  definitions_section:
     patterns: [
       {
         include: "#includes"
@@ -74,96 +106,75 @@ patterns: [
         ]
       }
     ]
-  }
-  {
-    begin: "^(%%)$"
-    beginCaptures:
-      1:
-        name: "punctuation.separator.sections.jisonlex"
-    end: "\\Z.\\A(?# never end)"
+
+  rules_section:
     patterns: [
       {
-        begin: "^(?!%%$)"
-        comment: "second section of the file - rules"
-        end: "^(?=%%$)"
-        name: "meta.section.rules.jisonlex"
+        begin: "^(?!$)"
+        end: "$"
+        name: "meta.rule.jisonlex"
         patterns: [
           {
-            begin: "^(?!$)"
-            end: "$"
-            name: "meta.rule.jisonlex"
+            include: "#includes"
+          }
+          {
+            begin: "(?i)^(<(?:(?:[a-z_][a-z0-9_-]*,)*[a-z_][a-z0-9_-]|\\*)>)?(?:(<<EOF>>)(\\s*))?(?=\\S)"
+            beginCaptures:
+              1:
+                name: "keyword.other.start-condition.jisonlex"
+              2:
+                name: "keyword.operator.eof.jisonlex"
+              3:
+                name: "invalid.illegal.regexp.jisonlex"
+            comment: "rule pattern"
+            end: "(?=\\s)|$"
             patterns: [
               {
-                include: "#includes"
+                include: "#regexp"
               }
+            ]
+          }
+          {
+            begin: "(%\\{)"
+            beginCaptures:
+              1:
+                name: "punctuation.definition.code.jisonlex"
+            comment: "TODO: %} should override embedded scopes"
+            end: "(%\\})(.*)"
+            endCaptures:
+              1:
+                name: "punctuation.terminator.code.jisonlex"
+              2:
+                name: "invalid.illegal.ignored.jisonlex"
+            patterns: [
               {
-                begin: "(?i)^(<(?:(?:[a-z_][a-z0-9_-]*,)*[a-z_][a-z0-9_-]|\\*)>)?(?:(<<EOF>>)(\\s*))?(?=\\S)"
-                beginCaptures:
-                  1:
-                    name: "keyword.other.start-condition.jisonlex"
-                  2:
-                    name: "keyword.operator.eof.jisonlex"
-                  3:
-                    name: "invalid.illegal.regexp.jisonlex"
-                comment: "rule pattern"
-                end: "(?=\\s)|$"
-                patterns: [
-                  {
-                    include: "#regexp"
-                  }
-                ]
+                include: "#jssource"
               }
+            ]
+          }
+          {
+            begin: "(?=\\S)"
+            comment: "TODO: eol should override embedded scopes"
+            end: "$"
+            name: "meta.rule.action.jisonlex"
+            patterns: [
               {
-                begin: "(%\\{)"
-                beginCaptures:
-                  1:
-                    name: "punctuation.definition.code.jisonlex"
-                comment: "TODO: %} should override embedded scopes"
-                end: "(%\\})(.*)"
-                endCaptures:
-                  1:
-                    name: "punctuation.terminator.code.jisonlex"
-                  2:
-                    name: "invalid.illegal.ignored.jisonlex"
-                patterns: [
-                  {
-                    include: "#jssource"
-                  }
-                ]
-              }
-              {
-                begin: "(?=\\S)"
-                comment: "TODO: eol should override embedded scopes"
-                end: "$"
-                name: "meta.rule.action.jisonlex"
-                patterns: [
-                  {
-                    include: "#jssource"
-                  }
-                ]
+                include: "#jssource"
               }
             ]
           }
         ]
       }
+    ]
+
+  user_code_section:
+    patterns: [
       {
-        begin: "^(%%)$"
-        beginCaptures:
-          1:
-            name: "punctuation.separator.sections.jisonlex"
-        comment: "third section of the file - user code"
-        contentName: "meta.section.user-code.jisonlex"
-        end: "\\Z.\\A(?# never end)"
-        patterns: [
-          {
-            include: "#jssource"
-          }
-        ]
+        include: "#jssource"
       }
     ]
-  }
-]
-repository:
+
+
   jssource:
     patterns: [
       {

--- a/grammars/jisonlex.cson
+++ b/grammars/jisonlex.cson
@@ -21,7 +21,7 @@ patterns: [
       {
         begin: "^(?i)([a-z_][a-z0-9_-]*)(?=\\s|$)"
         beginCaptures:
-          "1":
+          1:
             name: "entity.name.function.jisonlex"
         end: "$"
         name: "meta.definition.jisonlex"
@@ -34,7 +34,7 @@ patterns: [
       {
         begin: "^(%[sx])(?=\\s|$)"
         beginCaptures:
-          "1":
+          1:
             name: "punctuation.definition.start-condition.jisonlex"
         end: "$"
         name: "meta.start-condition.jisonlex"
@@ -51,7 +51,7 @@ patterns: [
       {
         begin: "^(%option)\\s(?=\\S)"
         beginCaptures:
-          "1":
+          1:
             name: "keyword.other.option.jisonlex"
         end: "$"
         name: "meta.options.jisonlex"
@@ -78,7 +78,7 @@ patterns: [
   {
     begin: "^(%%)$"
     beginCaptures:
-      "1":
+      1:
         name: "punctuation.separator.sections.jisonlex"
     end: "\\Z.\\A(?# never end)"
     patterns: [
@@ -99,11 +99,11 @@ patterns: [
               {
                 begin: "(?i)^(<(?:(?:[a-z_][a-z0-9_-]*,)*[a-z_][a-z0-9_-]|\\*)>)?(?:(<<EOF>>)(\\s*))?(?=\\S)"
                 beginCaptures:
-                  "1":
+                  1:
                     name: "keyword.other.start-condition.jisonlex"
-                  "2":
+                  2:
                     name: "keyword.operator.eof.jisonlex"
-                  "3":
+                  3:
                     name: "invalid.illegal.regexp.jisonlex"
                 comment: "rule pattern"
                 end: "(?=\\s)|$"
@@ -116,14 +116,14 @@ patterns: [
               {
                 begin: "(%\\{)"
                 beginCaptures:
-                  "1":
+                  1:
                     name: "punctuation.definition.code.jisonlex"
                 comment: "TODO: %} should override embedded scopes"
                 end: "(%\\})(.*)"
                 endCaptures:
-                  "1":
+                  1:
                     name: "punctuation.terminator.code.jisonlex"
-                  "2":
+                  2:
                     name: "invalid.illegal.ignored.jisonlex"
                 patterns: [
                   {
@@ -149,7 +149,7 @@ patterns: [
       {
         begin: "^(%%)$"
         beginCaptures:
-          "1":
+          1:
             name: "punctuation.separator.sections.jisonlex"
         comment: "third section of the file - user code"
         contentName: "meta.section.user-code.jisonlex"
@@ -216,7 +216,7 @@ repository:
   regexp:
     begin: "\\G(?=\\S)(\\^)?"
     captures:
-      "1":
+      1:
         name: "keyword.control.anchor.regexp.jisonlex"
     end: "(\\$)?(?:(?=\\s)|$)"
     name: "string.regexp.jisonlex"
@@ -233,13 +233,13 @@ repository:
       {
         begin: "(\\[)(\\^)?-?"
         beginCaptures:
-          "1":
+          1:
             name: "punctuation.definition.character-class.set.jisonlex"
-          "2":
+          2:
             name: "keyword.operator.negation.regexp.jisonlex"
         end: "-?(\\])"
         endCaptures:
-          "1":
+          1:
             name: "punctuation.terminator.character-class.set.jisonlex"
         name: "constant.other.character-class.set.jisonlex"
         patterns: [
@@ -248,7 +248,7 @@ repository:
           }
           {
             captures:
-              "1":
+              1:
                 name: "invalid.illegal.regexp.jisonlex"
             match: "\\[:(?:(?:alnum|alpha|blank|cntrl|x?digit|graph|lower|print|punct|space|upper)|(.*?)):\\]"
             name: "constant.other.character-class.set.jisonlex"
@@ -287,7 +287,7 @@ repository:
       {
         begin: "([*+?])(?=[*+?])"
         beginCaptures:
-          "1":
+          1:
             name: "keyword.operator.quantifier.regexp.jisonlex"
         comment: "make ** or +? or other combinations illegal"
         end: "(?=[^*+?])"
@@ -310,11 +310,11 @@ repository:
       {
         begin: "(\\()"
         beginCaptures:
-          "1":
+          1:
             name: "punctuation.definition.group.regexp.jisonlex"
         end: "(\\))|(?=\\s)|$(?#end on whitespace because regex does)"
         endCaptures:
-          "1":
+          1:
             name: "punctuation.terminator.group.regexp.jisonlex"
         name: "meta.group.regexp.jisonlex"
         patterns: [
@@ -330,7 +330,7 @@ repository:
       {
         begin: "(/)"
         beginCaptures:
-          "1":
+          1:
             name: "keyword.operator.trailing-match.regexp.jisonlex"
         comment: "detection of multiple trailing contexts"
         end: "(?=\\s)|$"

--- a/grammars/jisonlex.cson
+++ b/grammars/jisonlex.cson
@@ -48,7 +48,7 @@ repository:
   definitions_section:
     patterns: [
       {include: "source.jison#comments"}
-
+      {include: "source.jison#include_declarations"}
       {
         name:  "meta.definition.jisonlex"
         begin: "\\b[\\p{Alpha}_](?:[\\w-]*\\w)?\\b"
@@ -142,6 +142,7 @@ repository:
 
   user_code_section:
     patterns: [
+      {include: "source.jison#user_code_include_declarations"}
       {include: "source.js"}
     ]
 

--- a/grammars/jisonlex.cson
+++ b/grammars/jisonlex.cson
@@ -1,41 +1,46 @@
 "name": "Jison Lex"
 scopeName: "source.jisonlex"
-fileTypes: [
-  "jisonlex"
-]
+fileTypes: ["jisonlex"]
+
 patterns: [
   {
-    begin: "\\A(?!%%$)"
-    comment: "first section of the file - definitions"
-    end: "^(?=%%$)"
-    name: "meta.section.definitions.jisonlex"
-    patterns: [include: "#definitions_section"]
-  }
-  {
-    begin: "^(%%)$"
-    beginCaptures:
-      1:
-        name: "meta.separator.section.jisonlex"
-    end: "\\Z.\\A(?# never end)"
+    # Like Flex (https://westes.github.io/flex/manual/Format.html), Jison Lex
+    # files are divided into three sections separated by %%:
+    #   definitions
+    #   %%
+    #   rules
+    #   %%
+    #   user code
+    # Flex has the additional requirement that the %% must be the only thing in
+    # a line, but that’s not the case for the separator between definitions and
+    # rules in Jison Lex.
+    begin: "%%"
+    beginCaptures: 0: name: "meta.separator.section.jisonlex"
     patterns: [
       {
-        begin: "^(?!%%$)"
-        comment: "second section of the file - rules"
-        end: "^(?=%%$)"
-        name: "meta.section.rules.jisonlex"
+        # The separator between rules and user code in Jison Lex must be at the
+        # beginning of a line.
+        begin: "^%%"
+        beginCaptures: 0: name: "meta.separator.section.jisonlex"
+        patterns: [
+          {
+            name:  "meta.section.user-code.jisonlex"
+            begin: "(?!%%)"
+            patterns: [include: "#user_code_section"]
+          }
+        ]
+      },{
+        name:  "meta.section.rules.jisonlex"
+        begin: "(?!%%)"
+        end:   "(?=^%%)"
         patterns: [include: "#rules_section"]
       }
-      {
-        begin: "^(%%)$"
-        beginCaptures:
-          1:
-            name: "meta.separator.section.jisonlex"
-        comment: "third section of the file - user code"
-        contentName: "meta.section.user-code.jisonlex"
-        end: "\\Z.\\A(?# never end)"
-        patterns: [include: "#user_code_section"]
-      }
     ]
+  },{
+    name:  "meta.section.definitions.jisonlex"
+    begin: "(?!%%)"
+    end:   "(?=%%)"
+    patterns: [include: "#definitions_section"]
   }
 ]
 

--- a/grammars/jisonlex.cson
+++ b/grammars/jisonlex.cson
@@ -47,11 +47,8 @@ patterns: [
 repository:
   definitions_section:
     patterns: [
-      {
-        begin: "/\\*"
-        end: "\\*/|$"
-        name: "comment.block.js.jisonlex"
-      }
+      {include: "source.jison#comments"}
+
       {
         begin: "^(?i)([a-z_][a-z0-9_-]*)(?=\\s|$)"
         beginCaptures:
@@ -60,6 +57,7 @@ repository:
         end: "$"
         name: "meta.definition.jisonlex"
         patterns: [
+          {include: "source.jison#comments"}
           {
             include: "#regexp"
           }
@@ -73,6 +71,7 @@ repository:
         end: "$"
         name: "meta.start-condition.jisonlex"
         patterns: [
+          {include: "source.jison#comments"}
           {
             match: "(?i)[a-z_][a-z0-9_-]*"
           }
@@ -112,6 +111,7 @@ repository:
 
   rules_section:
     patterns: [
+      {include: "source.jison#comments"}
       {
         begin: "^(?!$)"
         end: "$"

--- a/grammars/jisonlex.cson
+++ b/grammars/jisonlex.cson
@@ -50,34 +50,32 @@ repository:
       {include: "source.jison#comments"}
 
       {
-        begin: "^(?i)([a-z_][a-z0-9_-]*)(?=\\s|$)"
-        beginCaptures:
-          1:
-            name: "entity.name.function.jisonlex"
-        end: "$"
-        name: "meta.definition.jisonlex"
+        name:  "meta.definition.jisonlex"
+        begin: "\\b[\\p{Alpha}_](?:[\\w-]*\\w)?\\b"
+        end:   "$"
+        beginCaptures: 0: name: "entity.name.variable.jisonlex"
         patterns: [
           {include: "source.jison#comments"}
           {
-            include: "#regexp"
+            name:  "string.regexp.jisonlex"
+            begin: "(?=\\S)"
+            end:   "(?=\\s)"
+            patterns: [include: "#regexp"]
           }
         ]
-      }
-      {
-        begin: "^(%[sx])(?=\\s|$)"
-        beginCaptures:
-          1:
-            name: "punctuation.definition.start-condition.jisonlex"
-        end: "$"
-        name: "meta.start-condition.jisonlex"
+      },{
+        name:  "meta.start-condition.jisonlex"
+        begin: "%[sx]\\b"
+        end:   "$"
+        beginCaptures: 0: name: "keyword.other.start-condition.jisonlex"
         patterns: [
           {include: "source.jison#comments"}
           {
-            match: "(?i)[a-z_][a-z0-9_-]*"
-          }
-          {
+            name:  "entity.name.function.jisonlex"
+            match: "\\b[\\p{Alpha}_](?:[\\w-]*\\w)?\\b"
+          },{
+            name:  "invalid.illegal.jisonlex"
             match: "\\S"
-            name: "invalid.illegal.jisonlex"
           }
         ]
       }
@@ -93,40 +91,51 @@ repository:
     patterns: [
       {include: "source.jison#comments"}
       {
-        begin: "^(?!$)"
-        end: "$"
-        name: "meta.rule.jisonlex"
+        name:  "meta.start-conditions.jisonlex"
+        begin: "(?:^|(?<=%\\}))<(?!<EOF>>)"
+        end:   ">"
+        beginCaptures: 0: name: "punctuation.definition.start-conditions.begin.jisonlex"
+        endCaptures:   0: name: "punctuation.definition.start-conditions.end.jisonlex"
         patterns: [
           {
-            begin: "(?i)^(<(?:(?:[a-z_][a-z0-9_-]*,)*[a-z_][a-z0-9_-]|\\*)>)?(?:(<<EOF>>)(\\s*))?(?=\\S)"
-            beginCaptures:
-              1:
-                name: "keyword.other.start-condition.jisonlex"
-              2:
-                name: "keyword.operator.eof.jisonlex"
-              3:
-                name: "invalid.illegal.regexp.jisonlex"
-            comment: "rule pattern"
-            end: "(?=\\s)|$"
-            patterns: [
-              {
-                include: "#regexp"
-              }
-            ]
+            name:  "keyword.other.jisonlex"
+            match: "\\bINITIAL\\b"
           },{
-            name:  "meta.rule.action.jisonlex"
-            begin: "(?=%\\{)"
-            end:   "(?<=%\\})"
-            patterns: [include: "source.jison#user_code_blocks"]
+            name:  "entity.name.function.jisonlex"
+            match: "\\b[\\p{Alpha}_](?:[\\w-]*\\w)?\\b"
           },{
-            begin: "(?=\\S)"
-            comment: "TODO: eol should override embedded scopes"
-            end: "$"
-            name: "meta.rule.action.jisonlex"
-            patterns: [
-              {include: "source.js"}
-            ]
+            name:  "punctuation.separator.start-condition.jisonlex"
+            match: ","
+          },{
+            name:  "keyword.other.any-start-condition.jisonlex"
+            match: "(?<=<)\\*(?=>)"
+          },{
+            name:  "invalid.illegal.jisonlex"
+            match: "."
           }
+        ]
+      },{
+        name:  "meta.rule.action.jisonlex"
+        begin: "(?=%\\{)"
+        end:   "(?<=%\\})"
+        patterns: [include: "source.jison#user_code_blocks"]
+      },{
+        name:  "string.regexp.jisonlex"
+        begin: "(?:^|(?<=>|%\\}))(?=\\S)"
+        end:   "(?=\\s|%\\{)"
+        patterns: [include: "#regexp"]
+      },{
+        name:  "meta.rule.action.jisonlex"
+        begin: "(?=\\S)"
+        end:   "((//).*)?(?=$)"
+        endCaptures:
+          1: name: "comment.line.double-slash.js"
+          2: name: "punctuation.definition.comment.js"
+        # TODO: See the arrow (->) action in the Jison grammar for what’s going
+        # on with the duplicated JavaScript comment patterns.
+        patterns: [
+          {include: "source.jison#include_declarations"}
+          {include: "source.js"}
         ]
       }
     ]
@@ -136,138 +145,132 @@ repository:
       {include: "source.js"}
     ]
 
-  re_escape:
-    match: "\\\\(?i:[0-9]{1,3}|x[0-9a-f]{1,2}|.)"
-    name: "constant.character.escape.jisonlex"
-  regexp:
-    begin: "\\G(?=\\S)(\\^)?"
-    captures:
-      1:
-        name: "keyword.control.anchor.regexp.jisonlex"
-    end: "(\\$)?(?:(?=\\s)|$)"
-    name: "string.regexp.jisonlex"
+
+  name_uses:
     patterns: [
       {
-        include: "#subregexp"
+        name:  "variable.other.jisonlex"
+        match: "\\{[\\p{Alpha}_](?:[\\w-]*\\w)?\\}"
       }
     ]
-  subregexp:
+
+  # TODO: Can the regexp patterns be replaced with language-regexp
+  # (https://github.com/Alhadis/language-regexp) and some injections?
+  regexp:
     patterns: [
+      # Comments are allowed in Jison Lex regex patterns.
+      {include: "source.jison#comments"}
+      # These patterns are supported by JavaScript.
       {
-        include: "#re_escape"
-      }
-      {
-        begin: "(\\[)(\\^)?-?"
+        name:  "keyword.other.character-class.any.regexp.jisonlex"
+        match: "\\."
+      },{
+        name:  "keyword.other.anchor.word-boundary.regexp.jisonlex"
+        match: "\\\\b"
+      },{
+        name:  "keyword.other.anchor.non-word-boundary.regexp.jisonlex"
+        match: "\\\\B"
+      },{
+        name:  "keyword.other.anchor.start-of-input.regexp.jisonlex"
+        match: "\\^"
+      },{
+        name:  "keyword.other.anchor.end-of-input.regexp.jisonlex"
+        match: "\\$"
+      },{
+        name:  "keyword.other.back-reference.regexp.jisonlex"
+        match: "\\\\[1-9]\\d*"
+      },{
+        name:  "keyword.operator.quantifier.regexp.jisonlex"
+        match: "(?:[+*?]|\\{(?:\\d+(?:,(?:\\d+)?)?|,\\d+)\\})\\??"
+      },{
+        name:  "keyword.operator.alternation.regexp.jisonlex"
+        match: "\\|"
+      },{
+        name:  "meta.non-capturing.group.regexp.jisonlex"
+        begin: "\\(\\?:"
+        end:   "\\)"
+        beginCaptures: 0: name: "punctuation.definition.group.begin.regexp.jisonlex"
+        endCaptures:   0: name: "punctuation.definition.group.end.regexp.jisonlex"
+        patterns: [include: "#regexp"]
+      },{
+        name:  "meta.lookahead.assertion.regexp.jisonlex"
+        begin: "\\(\\?="
+        end:   "\\)"
+        beginCaptures: 0: name: "punctuation.definition.group.begin.regexp.jisonlex"
+        endCaptures:   0: name: "punctuation.definition.group.end.regexp.jisonlex"
+        patterns: [include: "#regexp"]
+      },{
+        name:  "meta.negative.lookahead.assertion.regexp.jisonlex"
+        begin: "\\(\\?!"
+        end:   "\\)"
+        beginCaptures: 0: name: "punctuation.definition.group.begin.regexp.jisonlex"
+        endCaptures:   0: name: "punctuation.definition.group.end.regexp.jisonlex"
+        patterns: [include: "#regexp"]
+      },{
+        name:  "meta.group.regexp.jisonlex"
+        begin: "\\("
+        end:   "\\)"
+        beginCaptures: 0: name: "punctuation.definition.group.begin.regexp.jisonlex"
+        endCaptures:   0: name: "punctuation.definition.group.end.regexp.jisonlex"
+        patterns: [include: "#regexp"]
+      },{
+        name:  "constant.other.character-class.set.regexp.jisonlex"
+        begin: "(\\[)(\\^)?"
+        end:   "\\]"
         beginCaptures:
-          1:
-            name: "punctuation.definition.character-class.set.jisonlex"
-          2:
-            name: "keyword.operator.negation.regexp.jisonlex"
-        end: "-?(\\])"
+          1: name: "punctuation.definition.character-class.begin.regexp.jisonlex"
+          2: name: "keyword.operator.negation.regexp.jisonlex"
         endCaptures:
-          1:
-            name: "punctuation.terminator.character-class.set.jisonlex"
-        name: "constant.other.character-class.set.jisonlex"
+          0: name: "punctuation.definition.character-class.end.regexp.jisonlex"
         patterns: [
-          {
-            include: "#re_escape"
-          }
-          {
-            captures:
-              1:
-                name: "invalid.illegal.regexp.jisonlex"
-            match: "\\[:(?:(?:alnum|alpha|blank|cntrl|x?digit|graph|lower|print|punct|space|upper)|(.*?)):\\]"
-            name: "constant.other.character-class.set.jisonlex"
-          }
+          {include: "#name_uses"}
+          {include: "#regexp_character_class"}
         ]
       }
+      {include: "#regexp_character_class"}
+      # These patterns are specific to Jison Lex.
+      {include: "#name_uses"}
+      {include: "source.jison#quoted_strings"}
       {
-        match: "(?i){[a-z_][a-z0-9_-]*}"
-        name: "variable.other.jisonlex"
-      }
-      {
-        begin: "\\{"
-        end: "\\}"
-        name: "keyword.operator.quantifier.regexp.jisonlex"
-        patterns: [
-          {
-            match: "(?<=\\{)[0-9]*(?:,[0-9]*)?(?=\\})"
-          }
-          {
-            comment: "{3} counts should only have digit[,digit]"
-            match: "[^}]"
-            name: "invalid.illegal.regexp.jisonlex"
-          }
-        ]
-      }
-      {
-        begin: "\""
-        end: "\""
-        name: "string.quoted.double.regexp.jisonlex"
-        patterns: [
-          {
-            include: "#re_escape"
-          }
-        ]
-      }
-      {
-        begin: "([*+?])(?=[*+?])"
-        beginCaptures:
-          1:
-            name: "keyword.operator.quantifier.regexp.jisonlex"
-        comment: "make ** or +? or other combinations illegal"
-        end: "(?=[^*+?])"
-        patterns: [
-          {
-            match: "."
-            name: "invalid.illegal.regexp.jisonlex"
-          }
-        ]
-      }
-      {
-        match: "[*+?]"
-        name: "keyword.operator.quantifier.regexp.jisonlex"
-      }
-      {
-        comment: "<<EOF>> is handled in the rule pattern"
+        name:  "keyword.other.eof.regexp.jisonlex"
         match: "<<EOF>>"
-        name: "invalid.illegal.regexp.jisonlex"
+      },{
+        name:  "keyword.operator.negative.lookahead.regexp.jisonlex"
+        match: "/!"
+      },{
+        name:  "keyword.operator.lookahead.regexp.jisonlex"
+        match: "/"
       }
+    ]
+
+  regexp_character_class:
+    patterns: [
+      # Character classes from
+      # https://github.com/atom/language-javascript/blob/master/grammars/regular%20expressions%20(javascript).cson
+      # and
+      # https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp
       {
-        begin: "(\\()"
-        beginCaptures:
-          1:
-            name: "punctuation.definition.group.regexp.jisonlex"
-        end: "(\\))|(?=\\s)|$(?#end on whitespace because regex does)"
-        endCaptures:
-          1:
-            name: "punctuation.terminator.group.regexp.jisonlex"
-        name: "meta.group.regexp.jisonlex"
-        patterns: [
-          {
-            match: "/"
-            name: "invalid.illegal.regexp.jisonlex"
-          }
-          {
-            include: "#subregexp"
-          }
-        ]
+        name:  "constant.character.escape.character-class.word.regexp.jisonlex"
+        match: "\\\\w"
+      },{
+        name:  "constant.character.escape.character-class.non-word.regexp.jisonlex"
+        match: "\\\\W"
+      },{
+        name:  "constant.character.escape.character-class.space.regexp.jisonlex"
+        match: "\\\\s"
+      },{
+        name:  "constant.character.escape.character-class.non-space.regexp.jisonlex"
+        match: "\\\\S"
+      },{
+        name:  "constant.character.escape.character-class.digit.regexp.jisonlex"
+        match: "\\\\d"
+      },{
+        name:  "constant.character.escape.character-class.non-digit.regexp.jisonlex"
+        match: "\\\\D"
+      },{
+        name:  "constant.character.escape.character-class.control.regexp.jisonlex"
+        match: "\\\\c[A-Z]"
       }
-      {
-        begin: "(/)"
-        beginCaptures:
-          1:
-            name: "keyword.operator.trailing-match.regexp.jisonlex"
-        comment: "detection of multiple trailing contexts"
-        end: "(?=\\s)|$"
-        patterns: [
-          {
-            match: "/|\\$(?!\\S)"
-            name: "invalid.illegal.regexp.jisonlex"
-          }
-          {
-            include: "#subregexp"
-          }
-        ]
-      }
+      # https://github.com/atom/language-javascript/blob/master/grammars/javascript.cson
+      {include: "source.js#string_escapes"}
     ]

--- a/grammars/jisonlex.cson
+++ b/grammars/jisonlex.cson
@@ -124,9 +124,7 @@ repository:
             end: "$"
             name: "meta.rule.action.jisonlex"
             patterns: [
-              {
-                include: "#jssource"
-              }
+              {include: "source.js"}
             ]
           }
         ]
@@ -135,37 +133,12 @@ repository:
 
   user_code_section:
     patterns: [
-      {
-        include: "#jssource"
-      }
-    ]
-
-
-  jssource:
-    patterns: [
-      {
-        match: "\\b(?:ECHO|BEGIN|REJECT|YY_FLUSH_BUFFER|YY_BREAK|yy(?:more|less|unput|input|terminate|text|leng|restart|_(?:push|pop|top)_state|_(?:create|switch_to|flush|delete)_buffer|_scan_(?:string|bytes|buffer)|_set_(?:bol|interactive))(?=\\(|$))\\b"
-        name: "support.function.js.jisonlex"
-      }
-      {
-        include: "source.js"
-      }
+      {include: "source.js"}
     ]
 
   re_escape:
     match: "\\\\(?i:[0-9]{1,3}|x[0-9a-f]{1,2}|.)"
     name: "constant.character.escape.jisonlex"
-  rec_csource:
-    begin: "\\{"
-    end: "\\}"
-    patterns: [
-      {
-        include: "source.js"
-      }
-      {
-        include: "#jssource"
-      }
-    ]
   regexp:
     begin: "\\G(?=\\S)(\\^)?"
     captures:

--- a/grammars/jisonlex.cson
+++ b/grammars/jisonlex.cson
@@ -15,7 +15,7 @@ patterns: [
     begin: "^(%%)$"
     beginCaptures:
       1:
-        name: "punctuation.separator.sections.jisonlex"
+        name: "meta.separator.section.jisonlex"
     end: "\\Z.\\A(?# never end)"
     patterns: [
       {
@@ -29,7 +29,7 @@ patterns: [
         begin: "^(%%)$"
         beginCaptures:
           1:
-            name: "punctuation.separator.sections.jisonlex"
+            name: "meta.separator.section.jisonlex"
         comment: "third section of the file - user code"
         contentName: "meta.section.user-code.jisonlex"
         end: "\\Z.\\A(?# never end)"

--- a/grammars/jisonlex.cson
+++ b/grammars/jisonlex.cson
@@ -2,6 +2,10 @@
 scopeName: "source.jisonlex"
 fileTypes: ["jisonlex"]
 
+# This grammar is based on the Jison Lex files from
+# https://github.com/zaach/lex-parser and
+# https://github.com/GerHobbelt/lex-parser.
+
 patterns: [
   {
     # Like Flex (https://westes.github.io/flex/manual/Format.html), Jison Lex
@@ -43,6 +47,7 @@ patterns: [
     patterns: [include: "#definitions_section"]
   }
 ]
+
 
 repository:
   definitions_section:

--- a/grammars/jisonlex.cson
+++ b/grammars/jisonlex.cson
@@ -48,9 +48,6 @@ repository:
   definitions_section:
     patterns: [
       {
-        include: "#includes"
-      }
-      {
         begin: "/\\*"
         end: "\\*/|$"
         name: "comment.block.js.jisonlex"
@@ -110,6 +107,7 @@ repository:
           }
         ]
       }
+      {include: "source.jison#user_code_blocks"}
     ]
 
   rules_section:
@@ -119,9 +117,6 @@ repository:
         end: "$"
         name: "meta.rule.jisonlex"
         patterns: [
-          {
-            include: "#includes"
-          }
           {
             begin: "(?i)^(<(?:(?:[a-z_][a-z0-9_-]*,)*[a-z_][a-z0-9_-]|\\*)>)?(?:(<<EOF>>)(\\s*))?(?=\\S)"
             beginCaptures:
@@ -138,26 +133,12 @@ repository:
                 include: "#regexp"
               }
             ]
-          }
-          {
-            begin: "(%\\{)"
-            beginCaptures:
-              1:
-                name: "punctuation.definition.code.jisonlex"
-            comment: "TODO: %} should override embedded scopes"
-            end: "(%\\})(.*)"
-            endCaptures:
-              1:
-                name: "punctuation.terminator.code.jisonlex"
-              2:
-                name: "invalid.illegal.ignored.jisonlex"
-            patterns: [
-              {
-                include: "#jssource"
-              }
-            ]
-          }
-          {
+          },{
+            name:  "meta.rule.action.jisonlex"
+            begin: "(?=%\\{)"
+            end:   "(?<=%\\})"
+            patterns: [include: "source.jison#user_code_blocks"]
+          },{
             begin: "(?=\\S)"
             comment: "TODO: eol should override embedded scopes"
             end: "$"
@@ -190,31 +171,7 @@ repository:
         include: "source.js"
       }
     ]
-  includes:
-    patterns: [
-      {
-        begin: "^%\\{$"
-        comment: "TODO: $} should override the embedded scopes"
-        end: "^%\\}$"
-        name: "meta.embedded.source.js.jisonlex"
-        patterns: [
-          {
-            include: "source.js"
-          }
-        ]
-      }
-      {
-        begin: "^[ \\t]+"
-        comment: "TODO: eol should override the embedded scopes"
-        end: "$"
-        name: "meta.embedded.source.js.jisonlex"
-        patterns: [
-          {
-            include: "source.js"
-          }
-        ]
-      }
-    ]
+
   re_escape:
     match: "\\\\(?i:[0-9]{1,3}|x[0-9a-f]{1,2}|.)"
     name: "constant.character.escape.jisonlex"

--- a/package.json
+++ b/package.json
@@ -6,6 +6,5 @@
   "license": "MIT",
   "engines": {
     "atom": ">0.50.0"
-  },
-  "dependencies": {}
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "language-jison",
   "version": "2.2.0",
-  "private": true,
   "description": "Syntax support for Jison files",
   "repository": "https://github.com/cdibbs/language-jison",
   "license": "MIT",

--- a/spec/include.js
+++ b/spec/include.js
@@ -1,0 +1,1 @@
+'include.js';

--- a/spec/language-jison-spec.coffee
+++ b/spec/language-jison-spec.coffee
@@ -1,0 +1,585 @@
+describe "language-jison", ->
+  beforeEach ->
+    waitsForPromise ->
+      atom.packages.activatePackage "language-jison"
+
+  describe "Jison grammar", ->
+    grammar = undefined
+
+    beforeEach ->
+      grammar = atom.grammars.grammarForScopeName "source.jison"
+
+    it "is defined", ->
+      expect(grammar.scopeName).toBe "source.jison"
+
+    it "tokenizes section separators", ->
+      lines = grammar.tokenizeLines """
+        %%
+        %%
+      """
+      tokens = lines[0]
+      expect(tokens.length).toBe 1
+      expect(tokens[0]).toEqual value: "%%", scopes: ["source.jison", "meta.separator.section.jison"]
+      tokens = lines[1]
+      expect(tokens.length).toBe 1
+      expect(tokens[0]).toEqual value: "%%", scopes: ["source.jison", "meta.separator.section.jison"]
+
+    it "tokenizes embedded lexers", ->
+      lines = grammar.tokenizeLines """
+        %lex
+
+        %%
+        /lex
+      """
+      tokens = lines[0]
+      expect(tokens.length).toBe 2
+      expect(tokens[0]).toEqual value: "%lex", scopes: ["source.jison", "meta.section.declarations.jison", "entity.name.tag.lexer.begin.jison"]
+      expect(tokens[1]).toEqual value: "", scopes: ["source.jison", "meta.section.declarations.jison"]
+      tokens = lines[1]
+      expect(tokens.length).toBe 1
+      expect(tokens[0]).toEqual value: "", scopes: ["source.jison", "meta.section.declarations.jison", "meta.section.definitions.jisonlex"]
+      tokens = lines[2]
+      expect(tokens.length).toBe 1
+      expect(tokens[0]).toEqual value: "%%", scopes: ["source.jison", "meta.section.declarations.jison", "meta.separator.section.jisonlex"]
+      tokens = lines[3]
+      expect(tokens.length).toBe 1
+      expect(tokens[0]).toEqual value: "/lex", scopes: ["source.jison", "meta.section.declarations.jison", "entity.name.tag.lexer.end.jison"]
+      lines = grammar.tokenizeLines """
+        %lex
+
+        %%
+
+        %%
+        /lex
+      """
+      tokens = lines[0]
+      expect(tokens.length).toBe 2
+      expect(tokens[0]).toEqual value: "%lex", scopes: ["source.jison", "meta.section.declarations.jison", "entity.name.tag.lexer.begin.jison"]
+      expect(tokens[1]).toEqual value: "", scopes: ["source.jison", "meta.section.declarations.jison"]
+      tokens = lines[1]
+      expect(tokens.length).toBe 1
+      expect(tokens[0]).toEqual value: "", scopes: ["source.jison", "meta.section.declarations.jison", "meta.section.definitions.jisonlex"]
+      tokens = lines[2]
+      expect(tokens.length).toBe 1
+      expect(tokens[0]).toEqual value: "%%", scopes: ["source.jison", "meta.section.declarations.jison", "meta.separator.section.jisonlex"]
+      tokens = lines[3]
+      expect(tokens.length).toBe 1
+      expect(tokens[0]).toEqual value: "", scopes: ["source.jison", "meta.section.declarations.jison", "meta.section.rules.jisonlex"]
+      tokens = lines[4]
+      expect(tokens.length).toBe 1
+      expect(tokens[0]).toEqual value: "%%", scopes: ["source.jison", "meta.section.declarations.jison", "meta.separator.section.jisonlex"]
+      tokens = lines[5]
+      expect(tokens.length).toBe 1
+      expect(tokens[0]).toEqual value: "/lex", scopes: ["source.jison", "meta.section.declarations.jison", "entity.name.tag.lexer.end.jison"]
+
+    it "tokenizes prologues", ->
+      lines = grammar.tokenizeLines """
+        %{
+
+        %}%start start // comment
+      """
+      tokens = lines[0]
+      expect(tokens.length).toBe 1
+      expect(tokens[0]).toEqual value: "%{", scopes: ["source.jison", "meta.section.declarations.jison", "meta.section.prologue.jison", "meta.user-code-block.jison", "punctuation.definition.user-code-block.begin.jison"]
+      tokens = lines[1]
+      expect(tokens.length).toBe 1
+      expect(tokens[0]).toEqual value: "", scopes: ["source.jison", "meta.section.declarations.jison", "meta.section.prologue.jison", "meta.user-code-block.jison"]
+      tokens = lines[2]
+      expect(tokens.length).toBe 5
+      expect(tokens[0]).toEqual value: "%}", scopes: ["source.jison", "meta.section.declarations.jison", "meta.section.prologue.jison", "meta.user-code-block.jison", "punctuation.definition.user-code-block.end.jison"]
+      expect(tokens[1]).toEqual value: "%start", scopes: ["source.jison", "meta.section.declarations.jison", "keyword.other.declaration.start.jison"]
+      expect(tokens[2]).toEqual value: " start ", scopes: ["source.jison", "meta.section.declarations.jison"]
+      expect(tokens[3]).toEqual value: "//", scopes: ["source.jison", "meta.section.declarations.jison", "comment.line.double-slash.jison", "punctuation.definition.comment.jison"]
+      expect(tokens[4]).toEqual value: " comment", scopes: ["source.jison", "meta.section.declarations.jison", "comment.line.double-slash.jison"]
+
+    it "tokenizes %code declarations", ->
+      lines = grammar.tokenizeLines """
+        %code/**/init %include 'include.js'//comment
+        %code required %include "include.js"
+        %code 'init' {{}}
+        %code "required" -> return;//comment
+        %code requires %include include.js
+      """
+      tokens = lines[0]
+      expect(tokens.length).toBe 12
+      expect(tokens[0]).toEqual value: "%code", scopes: ["source.jison", "meta.section.declarations.jison", "meta.code.jison", "keyword.other.declaration.code.jison"]
+      expect(tokens[1]).toEqual value: "/*", scopes: ["source.jison", "meta.section.declarations.jison", "meta.code.jison", "comment.block.jison", "punctuation.definition.comment.begin.jison"]
+      expect(tokens[2]).toEqual value: "*/", scopes: ["source.jison", "meta.section.declarations.jison", "meta.code.jison", "comment.block.jison", "punctuation.definition.comment.end.jison"]
+      expect(tokens[3]).toEqual value: "init", scopes: ["source.jison", "meta.section.declarations.jison", "meta.code.jison", "keyword.other.code-qualifier.init.jison"]
+      expect(tokens[4]).toEqual value: " ", scopes: ["source.jison", "meta.section.declarations.jison", "meta.code.jison"]
+      expect(tokens[5]).toEqual value: "%include", scopes: ["source.jison", "meta.section.declarations.jison", "meta.code.jison", "meta.include.jison", "keyword.other.declaration.include.jison"]
+      expect(tokens[6]).toEqual value: " ", scopes: ["source.jison", "meta.section.declarations.jison", "meta.code.jison", "meta.include.jison"]
+      expect(tokens[7]).toEqual value: "'", scopes: ["source.jison", "meta.section.declarations.jison", "meta.code.jison", "meta.include.jison", "string.quoted.single.jison"]
+      expect(tokens[8]).toEqual value: "include.js", scopes: ["source.jison", "meta.section.declarations.jison", "meta.code.jison", "meta.include.jison", "string.quoted.single.jison"]
+      expect(tokens[9]).toEqual value: "'", scopes: ["source.jison", "meta.section.declarations.jison", "meta.code.jison", "meta.include.jison", "string.quoted.single.jison"]
+      expect(tokens[10]).toEqual value: "//", scopes: ["source.jison", "meta.section.declarations.jison", "meta.code.jison", "comment.line.double-slash.jison", "punctuation.definition.comment.jison"]
+      expect(tokens[11]).toEqual value: "comment", scopes: ["source.jison", "meta.section.declarations.jison", "meta.code.jison", "comment.line.double-slash.jison"]
+      tokens = lines[1]
+      expect(tokens.length).toBe 9
+      expect(tokens[0]).toEqual value: "%code", scopes: ["source.jison", "meta.section.declarations.jison", "meta.code.jison", "keyword.other.declaration.code.jison"]
+      expect(tokens[1]).toEqual value: " ", scopes: ["source.jison", "meta.section.declarations.jison", "meta.code.jison"]
+      expect(tokens[2]).toEqual value: "required", scopes: ["source.jison", "meta.section.declarations.jison", "meta.code.jison", "keyword.other.code-qualifier.required.jison"]
+      expect(tokens[3]).toEqual value: " ", scopes: ["source.jison", "meta.section.declarations.jison", "meta.code.jison"]
+      expect(tokens[4]).toEqual value: "%include", scopes: ["source.jison", "meta.section.declarations.jison", "meta.code.jison", "meta.include.jison", "keyword.other.declaration.include.jison"]
+      expect(tokens[5]).toEqual value: " ", scopes: ["source.jison", "meta.section.declarations.jison", "meta.code.jison", "meta.include.jison"]
+      expect(tokens[6]).toEqual value: '"', scopes: ["source.jison", "meta.section.declarations.jison", "meta.code.jison", "meta.include.jison", "string.quoted.double.jison"]
+      expect(tokens[7]).toEqual value: "include.js", scopes: ["source.jison", "meta.section.declarations.jison", "meta.code.jison", "meta.include.jison", "string.quoted.double.jison"]
+      expect(tokens[8]).toEqual value: '"', scopes: ["source.jison", "meta.section.declarations.jison", "meta.code.jison", "meta.include.jison", "string.quoted.double.jison"]
+      tokens = lines[2]
+      expect(tokens.length).toBe 8
+      expect(tokens[0]).toEqual value: "%code", scopes: ["source.jison", "meta.section.declarations.jison", "meta.code.jison", "keyword.other.declaration.code.jison"]
+      expect(tokens[1]).toEqual value: " ", scopes: ["source.jison", "meta.section.declarations.jison", "meta.code.jison"]
+      expect(tokens[2]).toEqual value: "'", scopes: ["source.jison", "meta.section.declarations.jison", "meta.code.jison", "string.quoted.single.jison"]
+      expect(tokens[3]).toEqual value: "init", scopes: ["source.jison", "meta.section.declarations.jison", "meta.code.jison", "string.quoted.single.jison"]
+      expect(tokens[4]).toEqual value: "'", scopes: ["source.jison", "meta.section.declarations.jison", "meta.code.jison", "string.quoted.single.jison"]
+      expect(tokens[5]).toEqual value: " ", scopes: ["source.jison", "meta.section.declarations.jison", "meta.code.jison"]
+      expect(tokens[6]).toEqual value: "{{", scopes: ["source.jison", "meta.section.declarations.jison", "meta.code.jison", "meta.action.jison", "punctuation.definition.action.begin.jison"]
+      expect(tokens[7]).toEqual value: "}}", scopes: ["source.jison", "meta.section.declarations.jison", "meta.code.jison", "meta.action.jison", "punctuation.definition.action.end.jison"]
+      tokens = lines[3]
+      expect(tokens.length).toBe 10
+      expect(tokens[0]).toEqual value: "%code", scopes: ["source.jison", "meta.section.declarations.jison", "meta.code.jison", "keyword.other.declaration.code.jison"]
+      expect(tokens[1]).toEqual value: " ", scopes: ["source.jison", "meta.section.declarations.jison", "meta.code.jison"]
+      expect(tokens[2]).toEqual value: '"', scopes: ["source.jison", "meta.section.declarations.jison", "meta.code.jison", "string.quoted.double.jison"]
+      expect(tokens[3]).toEqual value: "required", scopes: ["source.jison", "meta.section.declarations.jison", "meta.code.jison", "string.quoted.double.jison"]
+      expect(tokens[4]).toEqual value: '"', scopes: ["source.jison", "meta.section.declarations.jison", "meta.code.jison", "string.quoted.double.jison"]
+      expect(tokens[5]).toEqual value: " ", scopes: ["source.jison", "meta.section.declarations.jison", "meta.code.jison"]
+      expect(tokens[6]).toEqual value: "->", scopes: ["source.jison", "meta.section.declarations.jison", "meta.code.jison", "meta.action.jison", "punctuation.definition.action.arrow.jison"]
+      expect(tokens[7]).toEqual value: " return;", scopes: ["source.jison", "meta.section.declarations.jison", "meta.code.jison", "meta.action.jison"]
+      expect(tokens[8]).toEqual value: "//", scopes: ["source.jison", "meta.section.declarations.jison", "meta.code.jison", "meta.action.jison", "comment.line.double-slash.js", "punctuation.definition.comment.js"]
+      expect(tokens[9]).toEqual value: "comment", scopes: ["source.jison", "meta.section.declarations.jison", "meta.code.jison", "meta.action.jison", "comment.line.double-slash.js"]
+      tokens = lines[4]
+      expect(tokens.length).toBe 7
+      expect(tokens[0]).toEqual value: "%code", scopes: ["source.jison", "meta.section.declarations.jison", "meta.code.jison", "keyword.other.declaration.code.jison"]
+      expect(tokens[1]).toEqual value: " ", scopes: ["source.jison", "meta.section.declarations.jison", "meta.code.jison"]
+      expect(tokens[2]).toEqual value: "requires", scopes: ["source.jison", "meta.section.declarations.jison", "meta.code.jison", "string.unquoted.jison"]
+      expect(tokens[3]).toEqual value: " ", scopes: ["source.jison", "meta.section.declarations.jison", "meta.code.jison"]
+      expect(tokens[4]).toEqual value: "%include", scopes: ["source.jison", "meta.section.declarations.jison", "meta.code.jison", "meta.include.jison", "keyword.other.declaration.include.jison"]
+      expect(tokens[5]).toEqual value: " ", scopes: ["source.jison", "meta.section.declarations.jison", "meta.code.jison", "meta.include.jison"]
+      expect(tokens[6]).toEqual value: "include.js", scopes: ["source.jison", "meta.section.declarations.jison", "meta.code.jison", "meta.include.jison", "string.unquoted.jison"]
+
+    it "tokenizes %options declarations", ->
+      {tokens} = grammar.tokenizeLine "%options foo={x}// not-a-comment"
+      expect(tokens.length).toBe 7
+      expect(tokens[0]).toEqual value: "%options", scopes: ["source.jison", "meta.section.declarations.jison", "meta.options.jison", "keyword.other.options.jison"]
+      expect(tokens[1]).toEqual value: " ", scopes: ["source.jison", "meta.section.declarations.jison", "meta.options.jison"]
+      expect(tokens[2]).toEqual value: "foo", scopes: ["source.jison", "meta.section.declarations.jison", "meta.options.jison", "entity.name.constant.jison"]
+      expect(tokens[3]).toEqual value: "=", scopes: ["source.jison", "meta.section.declarations.jison", "meta.options.jison", "keyword.operator.option.assignment.jison"]
+      expect(tokens[4]).toEqual value: "{x}//", scopes: ["source.jison", "meta.section.declarations.jison", "meta.options.jison", "string.unquoted.jison"]
+      expect(tokens[5]).toEqual value: " ", scopes: ["source.jison", "meta.section.declarations.jison", "meta.options.jison"]
+      expect(tokens[6]).toEqual value: "not-a-comment", scopes: ["source.jison", "meta.section.declarations.jison", "meta.options.jison", "entity.name.constant.jison"]
+
+    it "tokenizes %token declarations", ->
+      lines = grammar.tokenizeLines """
+        %token TOKEN1 //comment
+        %token <type> TOKEN2 %%
+        %token TOKEN3 0x0123456789ABCDEF 'description';
+      """
+      tokens = lines[0]
+      expect(tokens.length).toBe 6
+      expect(tokens[0]).toEqual value: "%token", scopes: ["source.jison", "meta.section.declarations.jison", "meta.token.jison", "keyword.other.declaration.token.jison"]
+      expect(tokens[1]).toEqual value: " ", scopes: ["source.jison", "meta.section.declarations.jison", "meta.token.jison"]
+      expect(tokens[2]).toEqual value: "TOKEN1", scopes: ["source.jison", "meta.section.declarations.jison", "meta.token.jison", "entity.other.token.jison"]
+      expect(tokens[3]).toEqual value: " ", scopes: ["source.jison", "meta.section.declarations.jison", "meta.token.jison"]
+      expect(tokens[4]).toEqual value: "//", scopes: ["source.jison", "meta.section.declarations.jison", "meta.token.jison", "comment.line.double-slash.jison", "punctuation.definition.comment.jison"]
+      expect(tokens[5]).toEqual value: "comment", scopes: ["source.jison", "meta.section.declarations.jison", "meta.token.jison", "comment.line.double-slash.jison"]
+      # The next two lines seem like they’re supposed to be valid Jison %token
+      # declarations, but they don’t appear to work.
+      tokens = lines[1]
+      expect(tokens.length).toBe 7
+      expect(tokens[0]).toEqual value: "%token", scopes: ["source.jison", "meta.section.declarations.jison", "meta.token.jison", "keyword.other.declaration.token.jison"]
+      expect(tokens[1]).toEqual value: " ", scopes: ["source.jison", "meta.section.declarations.jison", "meta.token.jison"]
+      expect(tokens[2]).toEqual value: "<type>", scopes: ["source.jison", "meta.section.declarations.jison", "meta.token.jison", "invalid.unimplemented.jison"]
+      expect(tokens[3]).toEqual value: " ", scopes: ["source.jison", "meta.section.declarations.jison", "meta.token.jison"]
+      expect(tokens[4]).toEqual value: "TOKEN2", scopes: ["source.jison", "meta.section.declarations.jison", "meta.token.jison", "entity.other.token.jison"]
+      expect(tokens[5]).toEqual value: " ", scopes: ["source.jison", "meta.section.declarations.jison", "meta.token.jison"]
+      expect(tokens[6]).toEqual value: "%%", scopes: ["source.jison", "meta.section.declarations.jison", "meta.token.jison", "punctuation.terminator.declaration.token.jison"]
+      tokens = lines[2]
+      expect(tokens.length).toBe 11
+      expect(tokens[0]).toEqual value: "%token", scopes: ["source.jison", "meta.section.declarations.jison", "meta.token.jison", "keyword.other.declaration.token.jison"]
+      expect(tokens[1]).toEqual value: " ", scopes: ["source.jison", "meta.section.declarations.jison", "meta.token.jison"]
+      expect(tokens[2]).toEqual value: "TOKEN3", scopes: ["source.jison", "meta.section.declarations.jison", "meta.token.jison", "entity.other.token.jison"]
+      expect(tokens[3]).toEqual value: " ", scopes: ["source.jison", "meta.section.declarations.jison", "meta.token.jison"]
+      expect(tokens[4]).toEqual value: "0x", scopes: ["source.jison", "meta.section.declarations.jison", "meta.token.jison", "storage.type.number.jison"]
+      expect(tokens[5]).toEqual value: "0123456789ABCDEF", scopes: ["source.jison", "meta.section.declarations.jison", "meta.token.jison", "constant.numeric.integer.hexadecimal.jison"]
+      expect(tokens[6]).toEqual value: " ", scopes: ["source.jison", "meta.section.declarations.jison", "meta.token.jison"]
+      expect(tokens[7]).toEqual value: "'", scopes: ["source.jison", "meta.section.declarations.jison", "meta.token.jison", "string.quoted.single.jison"]
+      expect(tokens[8]).toEqual value: "description", scopes: ["source.jison", "meta.section.declarations.jison", "meta.token.jison", "string.quoted.single.jison"]
+      expect(tokens[9]).toEqual value: "'", scopes: ["source.jison", "meta.section.declarations.jison", "meta.token.jison", "string.quoted.single.jison"]
+      expect(tokens[10]).toEqual value: ";", scopes: ["source.jison", "meta.section.declarations.jison", "meta.token.jison", "punctuation.terminator.declaration.token.jison"]
+
+    it "tokenizes rules", ->
+      lines = grammar.tokenizeLines """
+        %%
+        start: expression;
+        expression
+        : TOKEN {$$ = [$1];}
+        | expression '+'[add] expression %{ $$ = `${@add.first_line}`; %}
+        | '-' expression %prec UMINUS { yysp; }
+        | "(" expression ")" %include include.js //comment
+        | error -> yyclearin;yyerrok;//comment
+        ;
+      """
+      tokens = lines[0]
+      expect(tokens.length).toBe 1
+      expect(tokens[0]).toEqual value: "%%", scopes: ["source.jison", "meta.separator.section.jison"]
+      tokens = lines[1]
+      expect(tokens.length).toBe 4
+      expect(tokens[0]).toEqual value: "start", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "entity.name.constant.rule-result.jison"]
+      expect(tokens[1]).toEqual value: ":", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "keyword.operator.rule-components.assignment.jison"]
+      expect(tokens[2]).toEqual value: " expression", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison"]
+      expect(tokens[3]).toEqual value: ";", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "punctuation.terminator.rule.jison"]
+      tokens = lines[2]
+      expect(tokens.length).toBe 1
+      expect(tokens[0]).toEqual value: "expression", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "entity.name.constant.rule-result.jison"]
+      tokens = lines[3]
+      expect(tokens.length).toBe 8
+      expect(tokens[0]).toEqual value: ":", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "keyword.operator.rule-components.assignment.jison"]
+      expect(tokens[1]).toEqual value: " TOKEN ", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison"]
+      expect(tokens[2]).toEqual value: "{", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "meta.action.jison", "punctuation.definition.action.begin.jison"]
+      expect(tokens[3]).toEqual value: "$$", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "meta.action.jison", "variable.language.semantic-value.jison"]
+      expect(tokens[4]).toEqual value: " = [", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "meta.action.jison"]
+      expect(tokens[5]).toEqual value: "$1", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "meta.action.jison", "support.variable.token-value.jison"]
+      expect(tokens[6]).toEqual value: "];", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "meta.action.jison"]
+      expect(tokens[7]).toEqual value: "}", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "meta.action.jison", "punctuation.definition.action.end.jison"]
+      tokens = lines[4]
+      expect(tokens.length).toBe 16
+      expect(tokens[0]).toEqual value: "|", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "keyword.operator.rule-components.separator.jison"]
+      expect(tokens[1]).toEqual value: " expression ", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison"]
+      expect(tokens[2]).toEqual value: "'", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "string.quoted.single.jison"]
+      expect(tokens[3]).toEqual value: "+", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "string.quoted.single.jison"]
+      expect(tokens[4]).toEqual value: "'", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "string.quoted.single.jison"]
+      expect(tokens[5]).toEqual value: "[", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "punctuation.definition.named-reference.begin.jison"]
+      expect(tokens[6]).toEqual value: "add", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "entity.name.other.reference.jison"]
+      expect(tokens[7]).toEqual value: "]", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "punctuation.definition.named-reference.end.jison"]
+      expect(tokens[8]).toEqual value: " expression ", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison"]
+      expect(tokens[9]).toEqual value: "%{", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "meta.action.jison", "meta.user-code-block.jison", "punctuation.definition.user-code-block.begin.jison"]
+      expect(tokens[10]).toEqual value: " ", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "meta.action.jison", "meta.user-code-block.jison"]
+      expect(tokens[11]).toEqual value: "$$", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "meta.action.jison", "meta.user-code-block.jison", "variable.language.semantic-value.jison"]
+      expect(tokens[12]).toEqual value: " = `${", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "meta.action.jison", "meta.user-code-block.jison"]
+      expect(tokens[13]).toEqual value: "@add", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "meta.action.jison", "meta.user-code-block.jison", "support.variable.token-location.jison"]
+      expect(tokens[14]).toEqual value: ".first_line}`; ", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "meta.action.jison", "meta.user-code-block.jison"]
+      expect(tokens[15]).toEqual value: "%}", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "meta.action.jison", "meta.user-code-block.jison", "punctuation.definition.user-code-block.end.jison"]
+      tokens = lines[5]
+      expect(tokens.length).toBe 15
+      expect(tokens[0]).toEqual value: "|", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "keyword.operator.rule-components.separator.jison"]
+      expect(tokens[1]).toEqual value: " ", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison"]
+      expect(tokens[2]).toEqual value: "'", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "string.quoted.single.jison"]
+      expect(tokens[3]).toEqual value: "-", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "string.quoted.single.jison"]
+      expect(tokens[4]).toEqual value: "'", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "string.quoted.single.jison"]
+      expect(tokens[5]).toEqual value: " expression ", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison"]
+      expect(tokens[6]).toEqual value: "%prec", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "meta.prec.jison", "keyword.other.prec.jison"]
+      expect(tokens[7]).toEqual value: " ", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "meta.prec.jison"]
+      expect(tokens[8]).toEqual value: "UMINUS", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "meta.prec.jison", "constant.other.token.jison"]
+      expect(tokens[9]).toEqual value: " ", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison"]
+      expect(tokens[10]).toEqual value: "{", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "meta.action.jison", "punctuation.definition.action.begin.jison"]
+      expect(tokens[11]).toEqual value: " ", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "meta.action.jison"]
+      expect(tokens[12]).toEqual value: "yysp", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "meta.action.jison", "variable.language.stack-index-0.jison"]
+      expect(tokens[13]).toEqual value: "; ", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "meta.action.jison"]
+      expect(tokens[14]).toEqual value: "}", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "meta.action.jison", "punctuation.definition.action.end.jison"]
+      tokens = lines[6]
+      expect(tokens.length).toBe 16
+      expect(tokens[0]).toEqual value: "|", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "keyword.operator.rule-components.separator.jison"]
+      expect(tokens[1]).toEqual value: " ", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison"]
+      expect(tokens[2]).toEqual value: '"', scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "string.quoted.double.jison"]
+      expect(tokens[3]).toEqual value: "(", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "string.quoted.double.jison"]
+      expect(tokens[4]).toEqual value: '"', scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "string.quoted.double.jison"]
+      expect(tokens[5]).toEqual value: " expression ", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison"]
+      expect(tokens[6]).toEqual value: '"', scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "string.quoted.double.jison"]
+      expect(tokens[7]).toEqual value: ")", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "string.quoted.double.jison"]
+      expect(tokens[8]).toEqual value: '"', scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "string.quoted.double.jison"]
+      expect(tokens[9]).toEqual value: " ", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison"]
+      expect(tokens[10]).toEqual value: "%include", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "meta.include.jison", "keyword.other.declaration.include.jison"]
+      expect(tokens[11]).toEqual value: " ", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "meta.include.jison"]
+      expect(tokens[12]).toEqual value: "include.js", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "meta.include.jison", "string.unquoted.jison"]
+      expect(tokens[13]).toEqual value: " ", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison"]
+      expect(tokens[14]).toEqual value: "//", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "comment.line.double-slash.jison", "punctuation.definition.comment.jison"]
+      expect(tokens[15]).toEqual value: "comment", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "comment.line.double-slash.jison"]
+      tokens = lines[7]
+      expect(tokens.length).toBe 12
+      expect(tokens[0]).toEqual value: "|", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "keyword.operator.rule-components.separator.jison"]
+      expect(tokens[1]).toEqual value: " ", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison"]
+      expect(tokens[2]).toEqual value: "error", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "keyword.other.error.jison"]
+      expect(tokens[3]).toEqual value: " ", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison"]
+      expect(tokens[4]).toEqual value: "->", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "meta.action.jison", "punctuation.definition.action.arrow.jison"]
+      expect(tokens[5]).toEqual value: " ", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "meta.action.jison"]
+      expect(tokens[6]).toEqual value: "yyclearin", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "meta.action.jison", "keyword.other.jison"]
+      expect(tokens[7]).toEqual value: ";", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "meta.action.jison"]
+      expect(tokens[8]).toEqual value: "yyerrok", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "meta.action.jison", "keyword.other.jison"]
+      expect(tokens[9]).toEqual value: ";", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "meta.action.jison"]
+      expect(tokens[10]).toEqual value: "//", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "meta.action.jison", "comment.line.double-slash.js", "punctuation.definition.comment.js"]
+      expect(tokens[11]).toEqual value: "comment", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "meta.action.jison", "comment.line.double-slash.js"]
+      tokens = lines[8]
+      expect(tokens.length).toBe 1
+      expect(tokens[0]).toEqual value: ";", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "punctuation.terminator.rule.jison"]
+
+    it "tokenizes empty rules", ->
+      for token in ["%empty", "%epsilon", "\u0190", "\u025B", "\u03B5", "\u03F5"]
+        {tokens} = grammar.tokenizeLine "%% rule: #{token};"
+        expect(tokens.length).toBe 7
+        expect(tokens[0]).toEqual value: "%%", scopes: ["source.jison", "meta.separator.section.jison"]
+        expect(tokens[1]).toEqual value: " ", scopes: ["source.jison", "meta.section.rules.jison"]
+        expect(tokens[2]).toEqual value: "rule", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "entity.name.constant.rule-result.jison"]
+        expect(tokens[3]).toEqual value: ":", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "keyword.operator.rule-components.assignment.jison"]
+        expect(tokens[4]).toEqual value: " ", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison"]
+        expect(tokens[5]).toEqual value: token, scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "keyword.other.empty.jison"]
+        expect(tokens[6]).toEqual value: ";", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "punctuation.terminator.rule.jison"]
+
+  describe "Jison Lex grammar", ->
+    grammar = undefined
+
+    beforeEach ->
+      grammar = atom.grammars.grammarForScopeName "source.jisonlex"
+
+    it "is defined", ->
+      expect(grammar.scopeName).toBe "source.jisonlex"
+
+    it "tokenizes section separators", ->
+      lines = grammar.tokenizeLines """
+        %%
+        %%
+      """
+      tokens = lines[0]
+      expect(tokens.length).toBe 1
+      expect(tokens[0]).toEqual value: "%%", scopes: ["source.jisonlex", "meta.separator.section.jisonlex"]
+      tokens = lines[1]
+      expect(tokens.length).toBe 1
+      expect(tokens[0]).toEqual value: "%%", scopes: ["source.jisonlex", "meta.separator.section.jisonlex"]
+
+    it "tokenizes comments", ->
+      lines = grammar.tokenizeLines """
+        /*
+         * comment
+         */
+        // comment
+        %%
+        /*
+         * comment
+         */
+        // comment
+        %%
+      """
+      tokens = lines[0]
+      expect(tokens.length).toBe 1
+      expect(tokens[0]).toEqual value: "/*", scopes: ["source.jisonlex", "meta.section.definitions.jisonlex", "comment.block.jison", "punctuation.definition.comment.begin.jison"]
+      tokens = lines[1]
+      expect(tokens.length).toBe 1
+      expect(tokens[0]).toEqual value: " * comment", scopes: ["source.jisonlex", "meta.section.definitions.jisonlex", "comment.block.jison"]
+      tokens = lines[2]
+      expect(tokens.length).toBe 2
+      expect(tokens[0]).toEqual value: " ", scopes: ["source.jisonlex", "meta.section.definitions.jisonlex", "comment.block.jison"]
+      expect(tokens[1]).toEqual value: "*/", scopes: ["source.jisonlex", "meta.section.definitions.jisonlex", "comment.block.jison", "punctuation.definition.comment.end.jison"]
+      tokens = lines[3]
+      expect(tokens.length).toBe 2
+      expect(tokens[0]).toEqual value: "//", scopes: ["source.jisonlex", "meta.section.definitions.jisonlex", "comment.line.double-slash.jison", "punctuation.definition.comment.jison"]
+      expect(tokens[1]).toEqual value: " comment", scopes: ["source.jisonlex", "meta.section.definitions.jisonlex", "comment.line.double-slash.jison"]
+      tokens = lines[4]
+      expect(tokens.length).toBe 1
+      expect(tokens[0]).toEqual value: "%%", scopes: ["source.jisonlex", "meta.separator.section.jisonlex"]
+      tokens = lines[5]
+      expect(tokens.length).toBe 1
+      expect(tokens[0]).toEqual value: "/*", scopes: ["source.jisonlex", "meta.section.rules.jisonlex", "comment.block.jison", "punctuation.definition.comment.begin.jison"]
+      tokens = lines[6]
+      expect(tokens.length).toBe 1
+      expect(tokens[0]).toEqual value: " * comment", scopes: ["source.jisonlex", "meta.section.rules.jisonlex", "comment.block.jison"]
+      tokens = lines[7]
+      expect(tokens.length).toBe 2
+      expect(tokens[0]).toEqual value: " ", scopes: ["source.jisonlex", "meta.section.rules.jisonlex", "comment.block.jison"]
+      expect(tokens[1]).toEqual value: "*/", scopes: ["source.jisonlex", "meta.section.rules.jisonlex", "comment.block.jison", "punctuation.definition.comment.end.jison"]
+      tokens = lines[8]
+      expect(tokens.length).toBe 2
+      expect(tokens[0]).toEqual value: "//", scopes: ["source.jisonlex", "meta.section.rules.jisonlex", "comment.line.double-slash.jison", "punctuation.definition.comment.jison"]
+      expect(tokens[1]).toEqual value: " comment", scopes: ["source.jisonlex", "meta.section.rules.jisonlex", "comment.line.double-slash.jison"]
+      tokens = lines[9]
+      expect(tokens.length).toBe 1
+      expect(tokens[0]).toEqual value: "%%", scopes: ["source.jisonlex", "meta.separator.section.jisonlex"]
+
+    it "tokenizes name definitions", ->
+      lines = grammar.tokenizeLines """
+        name1 definition
+        name2.
+        name3 ./**///%%
+        α-βγ.
+      """
+      tokens = lines[0]
+      expect(tokens.length).toBe 3
+      expect(tokens[0]).toEqual value: "name1", scopes: ["source.jisonlex", "meta.section.definitions.jisonlex", "meta.definition.jisonlex", "entity.name.variable.jisonlex"]
+      expect(tokens[1]).toEqual value: " ", scopes: ["source.jisonlex", "meta.section.definitions.jisonlex", "meta.definition.jisonlex"]
+      expect(tokens[2]).toEqual value: "definition", scopes: ["source.jisonlex", "meta.section.definitions.jisonlex", "meta.definition.jisonlex", "string.regexp.jisonlex"]
+      tokens = lines[1]
+      expect(tokens.length).toBe 2
+      expect(tokens[0]).toEqual value: "name2", scopes: ["source.jisonlex", "meta.section.definitions.jisonlex", "meta.definition.jisonlex", "entity.name.variable.jisonlex"]
+      expect(tokens[1]).toEqual value: ".", scopes: ["source.jisonlex", "meta.section.definitions.jisonlex", "meta.definition.jisonlex", "string.regexp.jisonlex", "keyword.other.character-class.any.regexp.jisonlex"]
+      tokens = lines[2]
+      expect(tokens.length).toBe 7
+      expect(tokens[0]).toEqual value: "name3", scopes: ["source.jisonlex", "meta.section.definitions.jisonlex", "meta.definition.jisonlex", "entity.name.variable.jisonlex"]
+      expect(tokens[1]).toEqual value: " ", scopes: ["source.jisonlex", "meta.section.definitions.jisonlex", "meta.definition.jisonlex"]
+      expect(tokens[2]).toEqual value: ".", scopes: ["source.jisonlex", "meta.section.definitions.jisonlex", "meta.definition.jisonlex", "string.regexp.jisonlex", "keyword.other.character-class.any.regexp.jisonlex"]
+      expect(tokens[3]).toEqual value: "/*", scopes: ["source.jisonlex", "meta.section.definitions.jisonlex", "meta.definition.jisonlex", "string.regexp.jisonlex", "comment.block.jison", "punctuation.definition.comment.begin.jison"]
+      expect(tokens[4]).toEqual value: "*/", scopes: ["source.jisonlex", "meta.section.definitions.jisonlex", "meta.definition.jisonlex", "string.regexp.jisonlex", "comment.block.jison", "punctuation.definition.comment.end.jison"]
+      expect(tokens[5]).toEqual value: "//", scopes: ["source.jisonlex", "meta.section.definitions.jisonlex", "meta.definition.jisonlex", "string.regexp.jisonlex", "comment.line.double-slash.jison", "punctuation.definition.comment.jison"]
+      expect(tokens[6]).toEqual value: "%%", scopes: ["source.jisonlex", "meta.section.definitions.jisonlex", "meta.definition.jisonlex", "string.regexp.jisonlex", "comment.line.double-slash.jison"]
+      tokens = lines[3]
+      expect(tokens.length).toBe 2
+      expect(tokens[0]).toEqual value: "α-βγ", scopes: ["source.jisonlex", "meta.section.definitions.jisonlex", "meta.definition.jisonlex", "entity.name.variable.jisonlex"]
+      expect(tokens[1]).toEqual value: ".", scopes: ["source.jisonlex", "meta.section.definitions.jisonlex", "meta.definition.jisonlex", "string.regexp.jisonlex", "keyword.other.character-class.any.regexp.jisonlex"]
+
+    it "tokenizes %{ %} blocks in definitions", ->
+      lines = grammar.tokenizeLines """
+        %{
+
+        %} name.
+      """
+      tokens = lines[0]
+      expect(tokens.length).toBe 1
+      expect(tokens[0]).toEqual value: "%{", scopes: ["source.jisonlex", "meta.section.definitions.jisonlex", "meta.user-code-block.jison", "punctuation.definition.user-code-block.begin.jison"]
+      tokens = lines[1]
+      expect(tokens.length).toBe 1
+      expect(tokens[0]).toEqual value: "", scopes: ["source.jisonlex", "meta.section.definitions.jisonlex", "meta.user-code-block.jison"]
+      tokens = lines[2]
+      expect(tokens.length).toBe 4
+      expect(tokens[0]).toEqual value: "%}", scopes: ["source.jisonlex", "meta.section.definitions.jisonlex", "meta.user-code-block.jison", "punctuation.definition.user-code-block.end.jison"]
+      expect(tokens[1]).toEqual value: " ", scopes: ["source.jisonlex", "meta.section.definitions.jisonlex"]
+      expect(tokens[2]).toEqual value: "name", scopes: ["source.jisonlex", "meta.section.definitions.jisonlex", "meta.definition.jisonlex", "entity.name.variable.jisonlex"]
+      expect(tokens[3]).toEqual value: ".", scopes: ["source.jisonlex", "meta.section.definitions.jisonlex", "meta.definition.jisonlex", "string.regexp.jisonlex", "keyword.other.character-class.any.regexp.jisonlex"]
+
+    it "tokenizes rules without start conditions", ->
+      lines = grammar.tokenizeLines """
+        %%
+        <<EOF>>
+        %{
+          return yytext;
+        %}
+      """
+      tokens = lines[0]
+      expect(tokens.length).toBe 1
+      expect(tokens[0]).toEqual value: "%%", scopes: ["source.jisonlex", "meta.separator.section.jisonlex"]
+      tokens = lines[1]
+      expect(tokens.length).toBe 1
+      expect(tokens[0]).toEqual value: "<<EOF>>", scopes: ["source.jisonlex", "meta.section.rules.jisonlex", "string.regexp.jisonlex", "keyword.other.eof.regexp.jisonlex"]
+      tokens = lines[2]
+      expect(tokens.length).toBe 1
+      expect(tokens[0]).toEqual value: "%{", scopes: ["source.jisonlex", "meta.section.rules.jisonlex", "meta.rule.action.jisonlex", "meta.user-code-block.jison", "punctuation.definition.user-code-block.begin.jison"]
+      tokens = lines[3]
+      expect(tokens.length).toBe 3
+      expect(tokens[0]).toEqual value: "  return ", scopes: ["source.jisonlex", "meta.section.rules.jisonlex", "meta.rule.action.jisonlex", "meta.user-code-block.jison"]
+      expect(tokens[1]).toEqual value: "yytext", scopes: ["source.jisonlex", "meta.section.rules.jisonlex", "meta.rule.action.jisonlex", "meta.user-code-block.jison", "variable.language.jisonlex"]
+      expect(tokens[2]).toEqual value: ";", scopes: ["source.jisonlex", "meta.section.rules.jisonlex", "meta.rule.action.jisonlex", "meta.user-code-block.jison"]
+      tokens = lines[4]
+      expect(tokens.length).toBe 1
+      expect(tokens[0]).toEqual value: "%}", scopes: ["source.jisonlex", "meta.section.rules.jisonlex", "meta.rule.action.jisonlex", "meta.user-code-block.jison", "punctuation.definition.user-code-block.end.jison"]
+
+    it "tokenizes rules with start conditions", ->
+      lines = grammar.tokenizeLines """
+        %%
+        <INITIAL>. // action
+        <x,_α-βγ>. // action
+        <*><<EOF>> // action
+        <x,*>. // action
+        <x, y>. // action
+      """
+      tokens = lines[0]
+      expect(tokens.length).toBe 1
+      expect(tokens[0]).toEqual value: "%%", scopes: ["source.jisonlex", "meta.separator.section.jisonlex"]
+      tokens = lines[1]
+      expect(tokens.length).toBe 7
+      expect(tokens[0]).toEqual value: "<", scopes: ["source.jisonlex", "meta.section.rules.jisonlex", "meta.start-conditions.jisonlex", "punctuation.definition.start-conditions.begin.jisonlex"]
+      expect(tokens[1]).toEqual value: "INITIAL", scopes: ["source.jisonlex", "meta.section.rules.jisonlex", "meta.start-conditions.jisonlex", "keyword.other.jisonlex"]
+      expect(tokens[2]).toEqual value: ">", scopes: ["source.jisonlex", "meta.section.rules.jisonlex", "meta.start-conditions.jisonlex", "punctuation.definition.start-conditions.end.jisonlex"]
+      tokens = lines[2]
+      expect(tokens.length).toBe 9
+      expect(tokens[0]).toEqual value: "<", scopes: ["source.jisonlex", "meta.section.rules.jisonlex", "meta.start-conditions.jisonlex", "punctuation.definition.start-conditions.begin.jisonlex"]
+      expect(tokens[1]).toEqual value: "x", scopes: ["source.jisonlex", "meta.section.rules.jisonlex", "meta.start-conditions.jisonlex", "entity.name.function.jisonlex"]
+      expect(tokens[2]).toEqual value: ",", scopes: ["source.jisonlex", "meta.section.rules.jisonlex", "meta.start-conditions.jisonlex", "punctuation.separator.start-condition.jisonlex"]
+      expect(tokens[3]).toEqual value: "_α-βγ", scopes: ["source.jisonlex", "meta.section.rules.jisonlex", "meta.start-conditions.jisonlex", "entity.name.function.jisonlex"]
+      expect(tokens[4]).toEqual value: ">", scopes: ["source.jisonlex", "meta.section.rules.jisonlex", "meta.start-conditions.jisonlex", "punctuation.definition.start-conditions.end.jisonlex"]
+      tokens = lines[3]
+      expect(tokens.length).toBe 7
+      expect(tokens[0]).toEqual value: "<", scopes: ["source.jisonlex", "meta.section.rules.jisonlex", "meta.start-conditions.jisonlex", "punctuation.definition.start-conditions.begin.jisonlex"]
+      expect(tokens[1]).toEqual value: "*", scopes: ["source.jisonlex", "meta.section.rules.jisonlex", "meta.start-conditions.jisonlex", "keyword.other.any-start-condition.jisonlex"]
+      expect(tokens[2]).toEqual value: ">", scopes: ["source.jisonlex", "meta.section.rules.jisonlex", "meta.start-conditions.jisonlex", "punctuation.definition.start-conditions.end.jisonlex"]
+      expect(tokens[3]).toEqual value: "<<EOF>>", scopes: ["source.jisonlex", "meta.section.rules.jisonlex", "string.regexp.jisonlex", "keyword.other.eof.regexp.jisonlex"]
+      tokens = lines[4]
+      expect(tokens.length).toBe 9
+      expect(tokens[0]).toEqual value: "<", scopes: ["source.jisonlex", "meta.section.rules.jisonlex", "meta.start-conditions.jisonlex", "punctuation.definition.start-conditions.begin.jisonlex"]
+      expect(tokens[1]).toEqual value: "x", scopes: ["source.jisonlex", "meta.section.rules.jisonlex", "meta.start-conditions.jisonlex", "entity.name.function.jisonlex"]
+      expect(tokens[2]).toEqual value: ",", scopes: ["source.jisonlex", "meta.section.rules.jisonlex", "meta.start-conditions.jisonlex", "punctuation.separator.start-condition.jisonlex"]
+      expect(tokens[3]).toEqual value: "*", scopes: ["source.jisonlex", "meta.section.rules.jisonlex", "meta.start-conditions.jisonlex", "invalid.illegal.jisonlex"]
+      expect(tokens[4]).toEqual value: ">", scopes: ["source.jisonlex", "meta.section.rules.jisonlex", "meta.start-conditions.jisonlex", "punctuation.definition.start-conditions.end.jisonlex"]
+      tokens = lines[5]
+      expect(tokens.length).toBe 10
+      expect(tokens[0]).toEqual value: "<", scopes: ["source.jisonlex", "meta.section.rules.jisonlex", "meta.start-conditions.jisonlex", "punctuation.definition.start-conditions.begin.jisonlex"]
+      expect(tokens[1]).toEqual value: "x", scopes: ["source.jisonlex", "meta.section.rules.jisonlex", "meta.start-conditions.jisonlex", "entity.name.function.jisonlex"]
+      expect(tokens[2]).toEqual value: ",", scopes: ["source.jisonlex", "meta.section.rules.jisonlex", "meta.start-conditions.jisonlex", "punctuation.separator.start-condition.jisonlex"]
+      expect(tokens[3]).toEqual value: " ", scopes: ["source.jisonlex", "meta.section.rules.jisonlex", "meta.start-conditions.jisonlex", "invalid.illegal.jisonlex"]
+      expect(tokens[4]).toEqual value: "y", scopes: ["source.jisonlex", "meta.section.rules.jisonlex", "meta.start-conditions.jisonlex", "entity.name.function.jisonlex"]
+      expect(tokens[5]).toEqual value: ">", scopes: ["source.jisonlex", "meta.section.rules.jisonlex", "meta.start-conditions.jisonlex", "punctuation.definition.start-conditions.end.jisonlex"]
+
+    it "tokenizes rules after %{ %} blocks", ->
+      lines = grammar.tokenizeLines """
+        %%
+        . %{ %}. code
+        .%{%}<INITIAL>. code
+      """
+      tokens = lines[0]
+      expect(tokens.length).toBe 1
+      expect(tokens[0]).toEqual value: "%%", scopes: ["source.jisonlex", "meta.separator.section.jisonlex"]
+      tokens = lines[1]
+      expect(tokens.length).toBe 8
+      expect(tokens[0]).toEqual value: ".", scopes: ["source.jisonlex", "meta.section.rules.jisonlex", "string.regexp.jisonlex", "keyword.other.character-class.any.regexp.jisonlex"]
+      expect(tokens[1]).toEqual value: " ", scopes: ["source.jisonlex", "meta.section.rules.jisonlex"]
+      expect(tokens[2]).toEqual value: "%{", scopes: ["source.jisonlex", "meta.section.rules.jisonlex", "meta.rule.action.jisonlex", "meta.user-code-block.jison", "punctuation.definition.user-code-block.begin.jison"]
+      expect(tokens[3]).toEqual value: " ", scopes: ["source.jisonlex", "meta.section.rules.jisonlex", "meta.rule.action.jisonlex", "meta.user-code-block.jison"]
+      expect(tokens[4]).toEqual value: "%}", scopes: ["source.jisonlex", "meta.section.rules.jisonlex", "meta.rule.action.jisonlex", "meta.user-code-block.jison", "punctuation.definition.user-code-block.end.jison"]
+      expect(tokens[5]).toEqual value: ".", scopes: ["source.jisonlex", "meta.section.rules.jisonlex", "string.regexp.jisonlex", "keyword.other.character-class.any.regexp.jisonlex"]
+      expect(tokens[6]).toEqual value: " ", scopes: ["source.jisonlex", "meta.section.rules.jisonlex"]
+      expect(tokens[7]).toEqual value: "code", scopes: ["source.jisonlex", "meta.section.rules.jisonlex", "meta.rule.action.jisonlex"]
+      tokens = lines[2]
+      expect(tokens.length).toBe 9
+      expect(tokens[0]).toEqual value: ".", scopes: ["source.jisonlex", "meta.section.rules.jisonlex", "string.regexp.jisonlex", "keyword.other.character-class.any.regexp.jisonlex"]
+      expect(tokens[1]).toEqual value: "%{", scopes: ["source.jisonlex", "meta.section.rules.jisonlex", "meta.rule.action.jisonlex", "meta.user-code-block.jison", "punctuation.definition.user-code-block.begin.jison"]
+      expect(tokens[2]).toEqual value: "%}", scopes: ["source.jisonlex", "meta.section.rules.jisonlex", "meta.rule.action.jisonlex", "meta.user-code-block.jison", "punctuation.definition.user-code-block.end.jison"]
+      expect(tokens[3]).toEqual value: "<", scopes: ["source.jisonlex", "meta.section.rules.jisonlex", "meta.start-conditions.jisonlex", "punctuation.definition.start-conditions.begin.jisonlex"]
+      expect(tokens[4]).toEqual value: "INITIAL", scopes: ["source.jisonlex", "meta.section.rules.jisonlex", "meta.start-conditions.jisonlex", "keyword.other.jisonlex"]
+      expect(tokens[5]).toEqual value: ">", scopes: ["source.jisonlex", "meta.section.rules.jisonlex", "meta.start-conditions.jisonlex", "punctuation.definition.start-conditions.end.jisonlex"]
+      expect(tokens[6]).toEqual value: ".", scopes: ["source.jisonlex", "meta.section.rules.jisonlex", "string.regexp.jisonlex", "keyword.other.character-class.any.regexp.jisonlex"]
+      expect(tokens[7]).toEqual value: " ", scopes: ["source.jisonlex", "meta.section.rules.jisonlex"]
+      expect(tokens[8]).toEqual value: "code", scopes: ["source.jisonlex", "meta.section.rules.jisonlex", "meta.rule.action.jisonlex"]
+
+    it "tokenizes %include declarations", ->
+      lines = grammar.tokenizeLines """
+        %include file.js
+        %%
+        . %include "file.js" // comment
+        %%
+        %include 'file.js'
+      """
+      tokens = lines[0]
+      expect(tokens.length).toBe 3
+      expect(tokens[0]).toEqual value: "%include", scopes: ["source.jisonlex", "meta.section.definitions.jisonlex", "meta.include.jison", "keyword.other.declaration.include.jison"]
+      expect(tokens[1]).toEqual value: " ", scopes: ["source.jisonlex", "meta.section.definitions.jisonlex", "meta.include.jison"]
+      expect(tokens[2]).toEqual value: "file.js", scopes: ["source.jisonlex", "meta.section.definitions.jisonlex", "meta.include.jison", "string.unquoted.jison"]
+      tokens = lines[1]
+      expect(tokens.length).toBe 1
+      expect(tokens[0]).toEqual value: "%%", scopes: ["source.jisonlex", "meta.separator.section.jisonlex"]
+      tokens = lines[2]
+      expect(tokens.length).toBe 10
+      expect(tokens[0]).toEqual value: ".", scopes: ["source.jisonlex", "meta.section.rules.jisonlex", "string.regexp.jisonlex", "keyword.other.character-class.any.regexp.jisonlex"]
+      expect(tokens[1]).toEqual value: " ", scopes: ["source.jisonlex", "meta.section.rules.jisonlex"]
+      expect(tokens[2]).toEqual value: "%include", scopes: ["source.jisonlex", "meta.section.rules.jisonlex", "meta.rule.action.jisonlex", "meta.include.jison", "keyword.other.declaration.include.jison"]
+      expect(tokens[3]).toEqual value: " ", scopes: ["source.jisonlex", "meta.section.rules.jisonlex", "meta.rule.action.jisonlex", "meta.include.jison"]
+      expect(tokens[4]).toEqual value: '"', scopes: ["source.jisonlex", "meta.section.rules.jisonlex", "meta.rule.action.jisonlex", "meta.include.jison", "string.quoted.double.jison"]
+      expect(tokens[5]).toEqual value: "file.js", scopes: ["source.jisonlex", "meta.section.rules.jisonlex", "meta.rule.action.jisonlex", "meta.include.jison", "string.quoted.double.jison"]
+      expect(tokens[6]).toEqual value: '"', scopes: ["source.jisonlex", "meta.section.rules.jisonlex", "meta.rule.action.jisonlex", "meta.include.jison", "string.quoted.double.jison"]
+      expect(tokens[7]).toEqual value: " ", scopes: ["source.jisonlex", "meta.section.rules.jisonlex", "meta.rule.action.jisonlex"]
+      expect(tokens[8]).toEqual value: "//", scopes: ["source.jisonlex", "meta.section.rules.jisonlex", "meta.rule.action.jisonlex", "comment.line.double-slash.js", "punctuation.definition.comment.js"]
+      expect(tokens[9]).toEqual value: " comment", scopes: ["source.jisonlex", "meta.section.rules.jisonlex", "meta.rule.action.jisonlex", "comment.line.double-slash.js"]
+      tokens = lines[3]
+      expect(tokens.length).toBe 1
+      expect(tokens[0]).toEqual value: "%%", scopes: ["source.jisonlex", "meta.separator.section.jisonlex"]
+      tokens = lines[4]
+      expect(tokens.length).toBe 5
+      expect(tokens[0]).toEqual value: "%include", scopes: ["source.jisonlex", "meta.section.user-code.jisonlex", "meta.include.jison", "keyword.other.include.jison"]
+      expect(tokens[1]).toEqual value: " ", scopes: ["source.jisonlex", "meta.section.user-code.jisonlex", "meta.include.jison"]
+      expect(tokens[2]).toEqual value: "'", scopes: ["source.jisonlex", "meta.section.user-code.jisonlex", "meta.include.jison", "string.quoted.single.jison"]
+      expect(tokens[3]).toEqual value: "file.js", scopes: ["source.jisonlex", "meta.section.user-code.jisonlex", "meta.include.jison", "string.quoted.single.jison"]
+      expect(tokens[4]).toEqual value: "'", scopes: ["source.jisonlex", "meta.section.user-code.jisonlex", "meta.include.jison", "string.quoted.single.jison"]

--- a/spec/sample.jison
+++ b/spec/sample.jison
@@ -1,0 +1,58 @@
+/*
+ * comment
+ */
+// comment
+
+%lex
+name .
+%%
+{name} return yytext;
+%%
+console.log('hello, world');
+/lex
+
+%{
+  // prologue
+  function(){return;}
+%}%include include.js // comment
+
+%include include.js
+
+%code/**/init %include 'include.js'//comment
+%code required %include "include.js"
+%code 'init' {{ return; }}
+%code 'required' { return; }
+%code "init" %{ return; %}
+%code "required" -> return;//comment
+%code requires %include include.js
+
+%token TOKEN //comment
+
+%unrecognized
+
+%start start
+
+%%
+
+%{ function(){return;} %}
+{{ function(){return;} }}
+
+%include include.js
+
+start: expression;
+
+expression
+  : TOKEN { $$ = [$1]; }
+  | expression '+'[add] expression %{ $$ = `${@add.first_line}`; %}
+  | '-' expression %prec UMINUS { yysp; }
+  | "(" expression ")" %include include.js //comment
+  | error -> yyclearin;yyerrok;//comment
+  ;
+
+empty1: /* empty */ { $$ = []; } | %empty { $$ = []; } | %epsilon { $$ = []; };
+empty2: ε { $$ = []; } | Ɛ { $$ = []; } | ɛ { $$ = []; } | ϵ { $$ = []; };
+
+%%
+
+%include 'include.js'
+console.log('hello, world');

--- a/spec/sample.jisonlex
+++ b/spec/sample.jisonlex
@@ -1,0 +1,47 @@
+/*
+ * comment
+ */
+// comment
+
+name1 ^[+*?/!/\]{/*not a comment*///not a comment][^set].$<<EOF>>
+x     "y"
+name2 [{x}]*/{x}?|/!{x}+|(?:\w)+(?=\d)*(?!\S)?(/!"x")|\n|.
+name3 ./*comment/!/*/.//comment/!/%%
+αβγ.
+
+%{
+  function(){return;};
+%}// comment
+
+%s start_condition x
+%x _αβγ
+
+%options foo={x}// not-a-comment
+%include include.js
+
+%%
+
+/*
+ * comment
+ */
+// comment
+
+<INITIAL>. return yytext; // comment
+<x,_αβγ>. // comment
+<*><<EOF>> %include "include.js" // comment
+<<EOF>>
+%{
+  /* yyleng yylineno yylloc yytext */ // yyleng yylineno yylloc yytext
+  "yytext"; 'yytext'; `yytext${yytext + "yytext"}`;
+  /yytext/;
+  return yytext;
+%}
+
+{name1} return 1;
+{name2} return 2;
+{name3} return 3;
+
+%%
+
+%include 'include.js'
+console.log('hello, world');

--- a/styles/atomjison-grammar-syntax.less
+++ b/styles/atomjison-grammar-syntax.less
@@ -3,7 +3,6 @@ atom-text-editor.editor {
     .syntax--source.syntax--jisonlex {
         .syntax--constant.syntax--rule-result.syntax--jison {
             font-weight: bold;
-            color: orange;
         }
     }
 }

--- a/styles/atomjison-grammar-syntax.less
+++ b/styles/atomjison-grammar-syntax.less
@@ -1,7 +1,7 @@
 atom-text-editor.editor {
     .syntax--source.syntax--jison,
     .syntax--source.syntax--jisonlex {
-        .syntax--grammar-rule.syntax--token-def.syntax--jison {
+        .syntax--constant.syntax--rule-result.syntax--jison {
             font-weight: bold;
             color: orange;
         }


### PR DESCRIPTION
This pull request is a pretty big update of the Jison grammars. I tried to structure the commits to make things clear, but a few things worth noting are:

* Lexers between `%lex` and `/lex` in Jison files are now tokenized.
* Grammar rules can include line breaks.
* There’s now a test suite.

Here are some potential “gotchas”:

* Even though this package is published at https://atom.io/packages/language-jison, the package.json has `"private"` set to `true`. I removed the `"private"` key from package.json.
* The package.json lists the license as MIT; I added an MIT license to this repository.
* I removed the orange color from grammar rule results because that color doesn’t seem to work well with all color themes. Grammar rule results are still bold.