### PR TITLE
Grammar tweaks

### DIFF
--- a/grammars/jison.cson
+++ b/grammars/jison.cson
@@ -296,7 +296,8 @@ repository:
       {include: "#include_declarations"}
       {
         name:  "meta.action.jison"
-        begin: "->"
+        # GerHobbelt Jison supports -> and → (U+2192 RIGHTWARDS ARROW).
+        begin: "(?:->|→)"
         end:   "((//).*)?(?=$)"
         beginCaptures:
           0: name: "punctuation.definition.action.arrow.jison"

--- a/grammars/jison.cson
+++ b/grammars/jison.cson
@@ -439,7 +439,9 @@ repository:
 
 # These are from https://github.com/GerHobbelt/jison/blob/master/lib/jison.js.
 injections:
-  "L:meta.action.jison -(comment | string), source.js.embedded.source":
+  # Putting parentheses around the selector following L: may be required; see
+  # https://github.com/github/linguist/issues/3612.
+  "L:(meta.action.jison - (comment | string)), source.js.embedded.source":
     patterns: [
       {
         name:  "variable.language.semantic-value.jison"

--- a/grammars/jison.cson
+++ b/grammars/jison.cson
@@ -386,6 +386,7 @@ repository:
         end:   "$"
         beginCaptures: 0: name: "keyword.other.options.jison"
         patterns: [
+          {include: "#comments"}
           {
             name:  "entity.name.constant.jison"
             match: "\\b[[:alpha:]_](?:[\\w-]*\\w)?\\b"

--- a/grammars/jisonlex-injection.cson
+++ b/grammars/jisonlex-injection.cson
@@ -12,14 +12,14 @@ scopeName: "source.jisonlex-injection"
 #
 # This replacement even occurs in comments and JavaScript strings, but it seems
 # unnecessary to highlight these strings in comments. Replacing
-#   "L:meta.rule.action.jisonlex -comment"
+#   "L:(meta.rule.action.jisonlex - comment)"
 # with
-#   "L:meta.rule.action.jisonlex -(comment | string), source.js.embedded.source"
+#   "L:(meta.rule.action.jisonlex - (comment | string)), source.js.embedded.source"
 # will eliminate highlighting in strings, but something like
 #  `${"yytext"}`
 # will still not be highlighted correctly. The L: prefix makes sure that things
 # like the “yylloc” in “yylloc.first_line” are highlighted correctly.
-injectionSelector: "L:meta.rule.action.jisonlex -comment"
+injectionSelector: "L:(meta.rule.action.jisonlex - comment)"
 patterns: [
   {
     name:  "variable.language.jisonlex"

--- a/spec/language-jison-spec.coffee
+++ b/spec/language-jison-spec.coffee
@@ -227,6 +227,7 @@ describe "language-jison", ->
         | '-' expression %prec UMINUS { yysp; }
         | "(" expression ")" %include include.js //comment
         | error -> yyclearin;yyerrok;//comment
+        | %empty → //comment
         ;
       """
       tokens = lines[0]
@@ -319,6 +320,16 @@ describe "language-jison", ->
       expect(tokens[10]).toEqual value: "//", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "meta.action.jison", "comment.line.double-slash.js", "punctuation.definition.comment.js"]
       expect(tokens[11]).toEqual value: "comment", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "meta.action.jison", "comment.line.double-slash.js"]
       tokens = lines[8]
+      expect(tokens.length).toBe 8
+      expect(tokens[0]).toEqual value: "|", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "keyword.operator.rule-components.separator.jison"]
+      expect(tokens[1]).toEqual value: " ", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison"]
+      expect(tokens[2]).toEqual value: "%empty", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "keyword.other.empty.jison"]
+      expect(tokens[3]).toEqual value: " ", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison"]
+      expect(tokens[4]).toEqual value: "→", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "meta.action.jison", "punctuation.definition.action.arrow.jison"]
+      expect(tokens[5]).toEqual value: ' ', scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "meta.action.jison"]
+      expect(tokens[6]).toEqual value: "//", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "meta.action.jison", "comment.line.double-slash.js", "punctuation.definition.comment.js"]
+      expect(tokens[7]).toEqual value: "comment", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "meta.action.jison", "comment.line.double-slash.js"]
+      tokens = lines[9]
       expect(tokens.length).toBe 1
       expect(tokens[0]).toEqual value: ";", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "punctuation.terminator.rule.jison"]
 

--- a/spec/language-jison-spec.coffee
+++ b/spec/language-jison-spec.coffee
@@ -158,6 +158,7 @@ describe "language-jison", ->
     it "tokenizes %options declarations", ->
       lines = grammar.tokenizeLines """
         %options foo={x}// not-a-comment
+        %options no-default-action //comment
       """
       tokens = lines[0]
       expect(tokens.length).toBe 7
@@ -168,6 +169,14 @@ describe "language-jison", ->
       expect(tokens[4]).toEqual value: "{x}//", scopes: ["source.jison", "meta.section.declarations.jison", "meta.options.jison", "string.unquoted.jison"]
       expect(tokens[5]).toEqual value: " ", scopes: ["source.jison", "meta.section.declarations.jison", "meta.options.jison"]
       expect(tokens[6]).toEqual value: "not-a-comment", scopes: ["source.jison", "meta.section.declarations.jison", "meta.options.jison", "entity.name.constant.jison"]
+      tokens = lines[1]
+      expect(tokens.length).toBe 6
+      expect(tokens[0]).toEqual value: "%options", scopes: ["source.jison", "meta.section.declarations.jison", "meta.options.jison", "keyword.other.options.jison"]
+      expect(tokens[1]).toEqual value: " ", scopes: ["source.jison", "meta.section.declarations.jison", "meta.options.jison"]
+      expect(tokens[2]).toEqual value: "no-default-action", scopes: ["source.jison", "meta.section.declarations.jison", "meta.options.jison", "entity.name.constant.jison"]
+      expect(tokens[3]).toEqual value: " ", scopes: ["source.jison", "meta.section.declarations.jison", "meta.options.jison"]
+      expect(tokens[4]).toEqual value: "//", scopes: ["source.jison", "meta.section.declarations.jison", "meta.options.jison", "comment.line.double-slash.jison", "punctuation.definition.comment.jison"]
+      expect(tokens[5]).toEqual value: "comment", scopes: ["source.jison", "meta.section.declarations.jison", "meta.options.jison", "comment.line.double-slash.jison"]
 
     it "tokenizes %token declarations", ->
       lines = grammar.tokenizeLines """

--- a/spec/sample.jison
+++ b/spec/sample.jison
@@ -52,6 +52,7 @@ expression
   | '-' expression %prec UMINUS { yysp; }
   | "(" expression ")" %include include.js //comment
   | error -> yyclearin;yyerrok;//comment
+  | %empty → //comment
   ;
 
 empty1: /* empty */ { $$ = []; } | %empty { $$ = []; } | %epsilon { $$ = []; };


### PR DESCRIPTION
This pull request:

* Fixes highlighting of comments in `%options` declarations
* Highlights arrow actions that use → (U+2192 RIGHTWARDS ARROW) correctly
* Puts parentheses around injection selectors so that GitHub doesn’t highlight built-in Jison variables in comments and strings