### PR TITLE
Enable CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+# https://github.com/atom/ci
+
+language: generic
+
+os:
+  - linux
+  - osx
+
+script: curl --silent https://raw.githubusercontent.com/atom/ci/master/build-package.sh | sh

--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
 # Jison Atom package  
+
+[![Build status](https://travis-ci.org/cdibbs/language-jison.svg?branch=master)](https://travis-ci.org/cdibbs/language-jison)
+[![Build status](https://ci.appveyor.com/api/projects/status/TBD?svg=true)](https://ci.appveyor.com/project/cdibbs/language-jison)
+[![apm](https://img.shields.io/apm/dm/language-jison.svg)](https://atom.io/packages/language-jison)
+
 Adds syntax highlighting to Jison files in Atom.  
 
 Thanks to, and based in part on, the following projects:  

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,7 @@
+# https://github.com/atom/ci
+
+build_script:
+  - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/atom/ci/master/build-package.ps1'))
+
+skip_tags: true
+test: off


### PR DESCRIPTION
This pull request adds CI files and placeholder badges in README.md.

You’ll need to log in to Travis CI and AppVeyor (you can use your GitHub account) to get this working. The badges in the README.md show an unknown status, but the builds are passing:

[![Build status](https://travis-ci.org/nwhetsell/language-jison.svg?branch=master)](https://travis-ci.org/nwhetsell/language-jison)
[![Build status](https://ci.appveyor.com/api/projects/status/07ee1pfu51s926en?svg=true)](https://ci.appveyor.com/project/nwhetsell/language-jison)