### PR TITLE
Fix %parser-type declarations

### DIFF
--- a/grammars/jison.cson
+++ b/grammars/jison.cson
@@ -159,6 +159,19 @@ repository:
           }
         ]
       },{
+        name:  "meta.parser-type.jison"
+        begin: "%(parser-type)\\b"
+        end:   "$"
+        beginCaptures: 0: name: "keyword.other.declaration.$1.jison"
+        patterns: [
+          {include: "#comments"}
+          {include: "#quoted_strings"}
+          {
+            name:  "string.unquoted.jison"
+            match: "\\b[[:alpha:]_](?:[\\w-]*\\w)?\\b"
+          }
+        ]
+      },{
         # https://www.gnu.org/software/bison/manual/html_node/Token-Decl.html
         name:  "meta.token.jison"
         begin: "%(token)\\b"
@@ -179,7 +192,7 @@ repository:
         ]
       },{
         name:  "keyword.other.declaration.$1.jison"
-        match: "%(debug|import|parser-type)\\b"
+        match: "%(debug|import)\\b"
       }
 
       {

--- a/spec/language-jison-spec.coffee
+++ b/spec/language-jison-spec.coffee
@@ -178,6 +178,15 @@ describe "language-jison", ->
       expect(tokens[4]).toEqual value: "//", scopes: ["source.jison", "meta.section.declarations.jison", "meta.options.jison", "comment.line.double-slash.jison", "punctuation.definition.comment.jison"]
       expect(tokens[5]).toEqual value: "comment", scopes: ["source.jison", "meta.section.declarations.jison", "meta.options.jison", "comment.line.double-slash.jison"]
 
+    it "tokenizes %parser-type declarations", ->
+      {tokens} = grammar.tokenizeLine "%parser-type lr0//comment"
+      expect(tokens.length).toBe 5
+      expect(tokens[0]).toEqual value: "%parser-type", scopes: ["source.jison", "meta.section.declarations.jison", "meta.parser-type.jison", "keyword.other.declaration.parser-type.jison"]
+      expect(tokens[1]).toEqual value: " ", scopes: ["source.jison", "meta.section.declarations.jison", "meta.parser-type.jison"]
+      expect(tokens[2]).toEqual value: "lr0", scopes: ["source.jison", "meta.section.declarations.jison", "meta.parser-type.jison", "string.unquoted.jison"]
+      expect(tokens[3]).toEqual value: "//", scopes: ["source.jison", "meta.section.declarations.jison", "meta.parser-type.jison", "comment.line.double-slash.jison", "punctuation.definition.comment.jison"]
+      expect(tokens[4]).toEqual value: "comment", scopes: ["source.jison", "meta.section.declarations.jison", "meta.parser-type.jison", "comment.line.double-slash.jison"]
+
     it "tokenizes %token declarations", ->
       lines = grammar.tokenizeLines """
         %token TOKEN1 //comment


### PR DESCRIPTION
This pull request fixes an issue with `%parser-type` declarations. [Here](https://github.com/GerHobbelt/jison/blob/master/examples/dism_lr0.jison) is an example; the `lr0` should look like a string.