### PR TITLE
Replace ambiguous \h hexadecimal character type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,6 @@ os:
   - linux
   - osx
 
+dist: trusty
+
 script: curl --silent https://raw.githubusercontent.com/atom/ci/master/build-package.sh | sh

--- a/grammars/jison.cson
+++ b/grammars/jison.cson
@@ -382,7 +382,7 @@ repository:
   numbers:
     patterns: [
       {
-        match: "(0[Xx])(\\h+)"
+        match: "(0[Xx])([0-9A-Fa-f]+)"
         captures:
           1: name: "storage.type.number.jison"
           2: name: "constant.numeric.integer.hexadecimal.jison"


### PR DESCRIPTION
This is based on https://github.com/mmims/language-batchfile/pull/16. Apparently GitHub lacks [Oniguruma](https://github.com/kkos/oniguruma)’s `\h` character class.