### PR TITLE
Don’t use lookaheads for newlines or end-of-line anchors

### DIFF
--- a/grammars/jison.cson
+++ b/grammars/jison.cson
@@ -68,7 +68,7 @@ repository:
       # Jison declarations sections can have lexers embedded between %lex and
       # /lex.
       {
-        begin: "^\\s*(%lex)\\s*(?=\\n)"
+        begin: "^\\s*(%lex)\\s*$"
         end:   "^\\s*(/lex)\\b"
         # There may be a better choice of scope than “entity.name.tag”, but
         # using a tag scope makes the start and end matches stand out. Also, the
@@ -106,13 +106,13 @@ repository:
               },{
                 name:  "meta.section.rules.jisonlex"
                 begin: "\\G"
-                end:   "(?=^(?:%%|/lex))"
+                end:   "^(?=%%|/lex)"
                 patterns: [include: "source.jisonlex#rules_section"]
               }
             ]
           },{
             name:  "meta.section.definitions.jisonlex"
-            begin: "\\G"
+            begin: "^"
             end:   "(?=%%|/lex)"
             patterns: [include: "source.jisonlex#definitions_section"]
           }
@@ -315,19 +315,8 @@ repository:
         name:  "meta.action.jison"
         # GerHobbelt Jison supports -> and → (U+2192 RIGHTWARDS ARROW).
         begin: "->|→"
-        end:   "((//).*)?(?=$)"
-        beginCaptures:
-          0: name: "punctuation.definition.action.arrow.jison"
-        endCaptures:
-          1: name: "comment.line.double-slash.js"
-          2: name: "punctuation.definition.comment.js"
-        # TODO: The end pattern is based on the comment.line.double-slash.js
-        # pattern in
-        # https://github.com/atom/language-javascript/blob/master/grammars/javascript.cson.
-        # The end pattern of comment.line.double-slash.js is itself $, so $
-        # can’t be the end pattern here because it will never be matched. Is
-        # there an end pattern that can be used here that doesn’t duplicate a
-        # JavaScript grammar pattern?
+        end:   "$"
+        beginCaptures: 0: name: "punctuation.definition.action.arrow.jison"
         contentName: "source.js.embedded.jison"
         patterns: [include: "source.js"]
       }
@@ -338,7 +327,7 @@ repository:
       {
         name:  "comment.line.double-slash.jison"
         begin: "//"
-        end:   "(?=\\n)"
+        end:   "$"
         beginCaptures: 0: name: "punctuation.definition.comment.jison"
       },{
         name:  "comment.block.jison"

--- a/grammars/jisonlex.cson
+++ b/grammars/jisonlex.cson
@@ -133,12 +133,7 @@ repository:
       },{
         name:  "meta.rule.action.jisonlex"
         begin: "(?=\\S)"
-        end:   "((//).*)?(?=$)"
-        endCaptures:
-          1: name: "comment.line.double-slash.js"
-          2: name: "punctuation.definition.comment.js"
-        # TODO: See the arrow (->) action in the Jison grammar for what’s going
-        # on with the duplicated JavaScript comment patterns.
+        end:   "$"
         contentName: "source.js.embedded.jison"
         patterns: [
           {include: "source.jison#include_declarations"}

--- a/spec/language-jison-spec.coffee
+++ b/spec/language-jison-spec.coffee
@@ -32,8 +32,9 @@ describe "language-jison", ->
         /lex
       """
       tokens = lines[0]
-      expect(tokens.length).toBe 1
+      expect(tokens.length).toBe 2
       expect(tokens[0]).toEqual value: "%lex", scopes: ["source.jison", "meta.section.declarations.jison", "entity.name.tag.lexer.begin.jison"]
+      expect(tokens[1]).toEqual value: "", scopes: ["source.jison", "meta.section.declarations.jison"]
       tokens = lines[1]
       expect(tokens.length).toBe 1
       expect(tokens[0]).toEqual value: "", scopes: ["source.jison", "meta.section.declarations.jison", "meta.section.definitions.jisonlex"]
@@ -52,8 +53,9 @@ describe "language-jison", ->
         /lex
       """
       tokens = lines[0]
-      expect(tokens.length).toBe 1
+      expect(tokens.length).toBe 2
       expect(tokens[0]).toEqual value: "%lex", scopes: ["source.jison", "meta.section.declarations.jison", "entity.name.tag.lexer.begin.jison"]
+      expect(tokens[1]).toEqual value: "", scopes: ["source.jison", "meta.section.declarations.jison"]
       tokens = lines[1]
       expect(tokens.length).toBe 1
       expect(tokens[0]).toEqual value: "", scopes: ["source.jison", "meta.section.declarations.jison", "meta.section.definitions.jisonlex"]
@@ -134,7 +136,7 @@ describe "language-jison", ->
       expect(tokens[6]).toEqual value: "{{", scopes: ["source.jison", "meta.section.declarations.jison", "meta.code.jison", "meta.action.jison", "punctuation.definition.action.begin.jison"]
       expect(tokens[7]).toEqual value: "}}", scopes: ["source.jison", "meta.section.declarations.jison", "meta.code.jison", "meta.action.jison", "punctuation.definition.action.end.jison"]
       tokens = lines[3]
-      expect(tokens.length).toBe 10
+      expect(tokens.length).toBe 8
       expect(tokens[0]).toEqual value: "%code", scopes: ["source.jison", "meta.section.declarations.jison", "meta.code.jison", "keyword.other.declaration.code.jison"]
       expect(tokens[1]).toEqual value: " ", scopes: ["source.jison", "meta.section.declarations.jison", "meta.code.jison"]
       expect(tokens[2]).toEqual value: '"', scopes: ["source.jison", "meta.section.declarations.jison", "meta.code.jison", "string.quoted.double.jison"]
@@ -142,9 +144,7 @@ describe "language-jison", ->
       expect(tokens[4]).toEqual value: '"', scopes: ["source.jison", "meta.section.declarations.jison", "meta.code.jison", "string.quoted.double.jison"]
       expect(tokens[5]).toEqual value: " ", scopes: ["source.jison", "meta.section.declarations.jison", "meta.code.jison"]
       expect(tokens[6]).toEqual value: "->", scopes: ["source.jison", "meta.section.declarations.jison", "meta.code.jison", "meta.action.jison", "punctuation.definition.action.arrow.jison"]
-      expect(tokens[7]).toEqual value: " return;", scopes: ["source.jison", "meta.section.declarations.jison", "meta.code.jison", "meta.action.jison", "source.js.embedded.jison"]
-      expect(tokens[8]).toEqual value: "//", scopes: ["source.jison", "meta.section.declarations.jison", "meta.code.jison", "meta.action.jison", "comment.line.double-slash.js", "punctuation.definition.comment.js"]
-      expect(tokens[9]).toEqual value: "comment", scopes: ["source.jison", "meta.section.declarations.jison", "meta.code.jison", "meta.action.jison", "comment.line.double-slash.js"]
+      expect(tokens[7]).toEqual value: " return;//comment", scopes: ["source.jison", "meta.section.declarations.jison", "meta.code.jison", "meta.action.jison", "source.js.embedded.jison"]
       tokens = lines[4]
       expect(tokens.length).toBe 7
       expect(tokens[0]).toEqual value: "%code", scopes: ["source.jison", "meta.section.declarations.jison", "meta.code.jison", "keyword.other.declaration.code.jison"]
@@ -380,7 +380,7 @@ describe "language-jison", ->
       expect(tokens[14]).toEqual value: "//", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "comment.line.double-slash.jison", "punctuation.definition.comment.jison"]
       expect(tokens[15]).toEqual value: "comment", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "comment.line.double-slash.jison"]
       tokens = lines[7]
-      expect(tokens.length).toBe 12
+      expect(tokens.length).toBe 10
       expect(tokens[0]).toEqual value: "|", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "keyword.operator.rule-components.separator.jison"]
       expect(tokens[1]).toEqual value: " ", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison"]
       expect(tokens[2]).toEqual value: "error", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "keyword.other.error.jison"]
@@ -390,19 +390,15 @@ describe "language-jison", ->
       expect(tokens[6]).toEqual value: "yyclearin", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "meta.action.jison", "source.js.embedded.jison", "keyword.other.jison"]
       expect(tokens[7]).toEqual value: ";", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "meta.action.jison", "source.js.embedded.jison"]
       expect(tokens[8]).toEqual value: "yyerrok", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "meta.action.jison", "source.js.embedded.jison", "keyword.other.jison"]
-      expect(tokens[9]).toEqual value: ";", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "meta.action.jison", "source.js.embedded.jison"]
-      expect(tokens[10]).toEqual value: "//", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "meta.action.jison", "comment.line.double-slash.js", "punctuation.definition.comment.js"]
-      expect(tokens[11]).toEqual value: "comment", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "meta.action.jison", "comment.line.double-slash.js"]
+      expect(tokens[9]).toEqual value: ";//comment", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "meta.action.jison", "source.js.embedded.jison"]
       tokens = lines[8]
-      expect(tokens.length).toBe 8
+      expect(tokens.length).toBe 6
       expect(tokens[0]).toEqual value: "|", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "keyword.operator.rule-components.separator.jison"]
       expect(tokens[1]).toEqual value: " ", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison"]
       expect(tokens[2]).toEqual value: "%empty", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "keyword.other.empty.jison"]
       expect(tokens[3]).toEqual value: " ", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison"]
       expect(tokens[4]).toEqual value: "→", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "meta.action.jison", "punctuation.definition.action.arrow.jison"]
-      expect(tokens[5]).toEqual value: ' ', scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "meta.action.jison", "source.js.embedded.jison"]
-      expect(tokens[6]).toEqual value: "//", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "meta.action.jison", "comment.line.double-slash.js", "punctuation.definition.comment.js"]
-      expect(tokens[7]).toEqual value: "comment", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "meta.action.jison", "comment.line.double-slash.js"]
+      expect(tokens[5]).toEqual value: " //comment", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "meta.rule-components.jison", "meta.action.jison", "source.js.embedded.jison"]
       tokens = lines[9]
       expect(tokens.length).toBe 1
       expect(tokens[0]).toEqual value: ";", scopes: ["source.jison", "meta.section.rules.jison", "meta.rule.jison", "punctuation.terminator.rule.jison"]
@@ -657,7 +653,7 @@ describe "language-jison", ->
       expect(tokens.length).toBe 1
       expect(tokens[0]).toEqual value: "%%", scopes: ["source.jisonlex", "meta.separator.section.jisonlex"]
       tokens = lines[2]
-      expect(tokens.length).toBe 10
+      expect(tokens.length).toBe 8
       expect(tokens[0]).toEqual value: ".", scopes: ["source.jisonlex", "meta.section.rules.jisonlex", "string.regexp.jisonlex", "keyword.other.character-class.any.regexp.jisonlex"]
       expect(tokens[1]).toEqual value: " ", scopes: ["source.jisonlex", "meta.section.rules.jisonlex"]
       expect(tokens[2]).toEqual value: "%include", scopes: ["source.jisonlex", "meta.section.rules.jisonlex", "meta.rule.action.jisonlex", "source.js.embedded.jison", "meta.include.jison", "keyword.other.declaration.include.jison"]
@@ -665,9 +661,7 @@ describe "language-jison", ->
       expect(tokens[4]).toEqual value: '"', scopes: ["source.jisonlex", "meta.section.rules.jisonlex", "meta.rule.action.jisonlex", "source.js.embedded.jison", "meta.include.jison", "string.quoted.double.jison"]
       expect(tokens[5]).toEqual value: "file.js", scopes: ["source.jisonlex", "meta.section.rules.jisonlex", "meta.rule.action.jisonlex", "source.js.embedded.jison", "meta.include.jison", "string.quoted.double.jison"]
       expect(tokens[6]).toEqual value: '"', scopes: ["source.jisonlex", "meta.section.rules.jisonlex", "meta.rule.action.jisonlex", "source.js.embedded.jison", "meta.include.jison", "string.quoted.double.jison"]
-      expect(tokens[7]).toEqual value: " ", scopes: ["source.jisonlex", "meta.section.rules.jisonlex", "meta.rule.action.jisonlex", "source.js.embedded.jison"]
-      expect(tokens[8]).toEqual value: "//", scopes: ["source.jisonlex", "meta.section.rules.jisonlex", "meta.rule.action.jisonlex", "comment.line.double-slash.js", "punctuation.definition.comment.js"]
-      expect(tokens[9]).toEqual value: " comment", scopes: ["source.jisonlex", "meta.section.rules.jisonlex", "meta.rule.action.jisonlex", "comment.line.double-slash.js"]
+      expect(tokens[7]).toEqual value: " // comment", scopes: ["source.jisonlex", "meta.section.rules.jisonlex", "meta.rule.action.jisonlex", "source.js.embedded.jison"]
       tokens = lines[3]
       expect(tokens.length).toBe 1
       expect(tokens[0]).toEqual value: "%%", scopes: ["source.jisonlex", "meta.separator.section.jisonlex"]


### PR DESCRIPTION
This pull request is analogous to pull request https://github.com/nwhetsell/language-csound/pull/3 – there are various changes to eliminate unnecessary lookaheads and matches of newlines.