### PR TITLE
Don’t scope Jison variables in comments and strings

### DIFF
--- a/grammars/jison.cson
+++ b/grammars/jison.cson
@@ -456,7 +456,7 @@ repository:
 injections:
   # Putting parentheses around the selector following L: may be required; see
   # https://github.com/github/linguist/issues/3612.
-  "L:(meta.action.jison - (comment | string)), source.js.embedded.jison":
+  "L:(meta.action.jison - (comment | string)), source.js.embedded.jison - (comment | string)":
     patterns: [
       {
         name:  "variable.language.semantic-value.jison"


### PR DESCRIPTION
This should fix an issue that causes Jison variables to be highlighted in comments and strings, for example:

https://github.com/nwhetsell/linter-csound/blob/d4156697097387b10c0f8832486c70484f4f2978/lib/csound-parser/orchestra.jison#L731