### PR TITLE
Fix highlighting in JavaScript template strings

### DIFF
--- a/grammars/jison.cson
+++ b/grammars/jison.cson
@@ -456,7 +456,7 @@ repository:
 injections:
   # Putting parentheses around the selector following L: may be required; see
   # https://github.com/github/linguist/issues/3612.
-  "L:(meta.action.jison - (comment | string)), source.js.embedded.jison - (comment | string)":
+  "L:(meta.action.jison - (comment | string)), source.js.embedded.jison - (comment | string), source.js.embedded.source - (comment | string.quoted.double | string.quoted.single)":
     patterns: [
       {
         name:  "variable.language.semantic-value.jison"


### PR DESCRIPTION
This adds an injection so things like `yyloc` are highlighted in JavaScript template strings.